### PR TITLE
Change how ci uploads coverage reports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,10 +22,6 @@ jobs:
         run: touch .env && docker compose run tests_with_coverage
       - name: Upload coverage to codecov
         uses: codecov/codecov-action@v3
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: true
-          verbose: true
   publish_package:
     if: startsWith(github.ref, 'refs/tags/v') && github.repository_owner == 'sinzlab'
     needs: [lint, test]


### PR DESCRIPTION
- Do not pass token because it is not needed for public repositories
- Do not fail ci if upload fails
- Disable verbose
