### PR TITLE
Update domain model and rewrite pull use case

### DIFF
--- a/dj_link/entities/link.py
+++ b/dj_link/entities/link.py
@@ -1,0 +1,71 @@
+"""Contains the link class."""
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from enum import Enum
+from typing import NewType
+
+
+class Components(Enum):
+    """Names for the different components in a link."""
+
+    SOURCE = 1
+    OUTBOUND = 2
+    LOCAL = 3
+
+
+Identifier = NewType("Identifier", str)
+
+
+@dataclass(frozen=True)
+class Link:
+    """The state of a link between two databases."""
+
+    source: set[Identifier]
+    outbound: set[Identifier]
+    local: set[Identifier]
+
+    def __post_init__(self) -> None:
+        """Validate the created link."""
+        assert self.outbound <= self.source, "Outbound must not be superset of source."
+        assert self.local == self.outbound, "Local and outbound must be identical."
+
+
+@dataclass(frozen=True)
+class Transfer:
+    """Specification for the transfer of an identifier from one component to another within a link."""
+
+    identifier: Identifier
+    origin: Components
+    destination: Components
+    identifier_only: bool
+
+    def __post_init__(self) -> None:
+        """Validate the created specification."""
+        assert self.origin is Components.SOURCE, "Origin must be source."
+        assert self.destination in (Components.OUTBOUND, Components.LOCAL), "Destiny must be outbound or local."
+        if self.destination is Components.OUTBOUND:
+            assert self.identifier_only, "Only identifier can be transferred to outbound."
+        else:
+            assert not self.identifier_only, "Whole entity must be transferred to local."
+
+
+def pull(
+    link: Link,
+    *,
+    requested: Iterable[Identifier],
+) -> set[Transfer]:
+    """Create the transfer specifications needed for pulling the requested identifiers."""
+    assert set(requested) <= link.source, "Requested must not be superset of source."
+    outbound_destined = set(requested) - link.outbound
+    local_destined = set(requested) - link.local
+    outbound_transfers = {
+        Transfer(i, origin=Components.SOURCE, destination=Components.OUTBOUND, identifier_only=True)
+        for i in outbound_destined
+    }
+    local_transfers = {
+        Transfer(i, origin=Components.SOURCE, destination=Components.LOCAL, identifier_only=False)
+        for i in local_destined
+    }
+    return outbound_transfers | local_transfers

--- a/dj_link/use_cases/pull.py
+++ b/dj_link/use_cases/pull.py
@@ -5,6 +5,7 @@ import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, List, Set
 
+from ..entities.link import Components, Identifier, Link, pull
 from .base import AbstractRequestModel, AbstractResponseModel, AbstractUseCase
 
 if TYPE_CHECKING:
@@ -52,17 +53,27 @@ class PullUseCase(AbstractUseCase[PullRequestModel, PullResponseModel]):  # pyli
 
     def execute(self, repo_link: RepositoryLink, request_model: PullRequestModel) -> PullResponseModel:
         """Pull the entities specified by the provided identifiers if they were not already pulled."""
-        valid_identifiers = [i for i in request_model.identifiers if i not in repo_link.outbound]
-        entities = [repo_link.source[identifier] for identifier in valid_identifiers]
-        with repo_link.outbound.transaction(), repo_link.local.transaction():
-            for entity in entities:
-                repo_link.outbound[entity.identifier] = entity.create_identifier_only_copy()
-                LOGGER.info(f"Inserted entity with identifier {entity.identifier} into outbound table")
-                repo_link.local[entity.identifier] = entity
-                LOGGER.info(f"Inserted entity with identifier {entity.identifier} into local table")
-        # noinspection PyArgumentList
+        valid_identifiers = {Identifier(i) for i in request_model.identifiers if i not in self.gateway_link.outbound}
+        link = Link(
+            source={Identifier(i) for i in self.gateway_link.source},
+            outbound={Identifier(i) for i in self.gateway_link.outbound},
+            local={Identifier(i) for i in self.gateway_link.local},
+        )
+        transfers = pull(link, requested=valid_identifiers)
+        gateway_map = {
+            Components.SOURCE: self.gateway_link.source,
+            Components.OUTBOUND: self.gateway_link.outbound,
+            Components.LOCAL: self.gateway_link.local,
+        }
+        for transfer in transfers:
+            origin = gateway_map[transfer.origin]
+            destination = gateway_map[transfer.destination]
+            entity = origin.fetch(transfer.identifier)
+            if transfer.identifier_only:
+                entity.create_identifier_only_copy()
+            destination.insert(entity)
         return self.response_model_cls(
             requested=set(request_model.identifiers),
-            valid=set(valid_identifiers),
-            invalid={i for i in request_model.identifiers if i not in valid_identifiers},
+            valid={str(i) for i in valid_identifiers},
+            invalid=set(request_model.identifiers) - valid_identifiers,
         )

--- a/dj_link/use_cases/pull.py
+++ b/dj_link/use_cases/pull.py
@@ -70,7 +70,7 @@ class PullUseCase(AbstractUseCase[PullRequestModel, PullResponseModel]):  # pyli
             destination = gateway_map[transfer.destination]
             entity = origin.fetch(transfer.identifier)
             if transfer.identifier_only:
-                entity.create_identifier_only_copy()
+                entity = entity.create_identifier_only_copy()
             destination.insert(entity)
         return self.response_model_cls(
             requested=set(request_model.identifiers),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,16 +95,20 @@ strict_concatenate = true
 [[tool.mypy.overrides]]
 module = [
     "dj_link.*",
+    "dj_link.entities.link",
     "tests.conftest",
     "tests.integration.test_pull",
+    "tests.unit.entities.test_link",
     "tests.unit.frameworks.datajoint.test_facade",
 ]
 ignore_errors = false
 
 [[tool.mypy.overrides]]
 module = [
+    "dj_link.entities.link",
     "tests.conftest",
     "tests.integration.test_pull",
+    "tests.unit.entities.test_link",
 ]
 disallow_any_generics = true
 disallow_untyped_calls = true

--- a/tests/unit/entities/test_link.py
+++ b/tests/unit/entities/test_link.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+from contextlib import nullcontext as does_not_raise
+from typing import ContextManager
+
+import pytest
+
+from dj_link.entities.link import Components, Identifier, Link, Transfer, pull
+
+
+class TestLink:
+    @staticmethod
+    @pytest.mark.parametrize(
+        "source,outbound,local,expectation",
+        [
+            (set(), {Identifier("1")}, {Identifier("1")}, pytest.raises(AssertionError)),
+            (set(), set(), set(), does_not_raise()),
+            ({Identifier("1")}, set(), set(), does_not_raise()),
+        ],
+    )
+    def test_outbound_identifiers_can_not_be_superset_of_source_identifiers(
+        source: set[Identifier], outbound: set[Identifier], local: set[Identifier], expectation: ContextManager[None]
+    ) -> None:
+        with expectation:
+            Link(source=source, outbound=outbound, local=local)
+
+    @staticmethod
+    @pytest.mark.parametrize(
+        "source,outbound,local,expectation",
+        [
+            ({Identifier("1")}, {Identifier("1")}, {Identifier("1")}, does_not_raise()),
+            ({Identifier("1")}, {Identifier("1")}, set(), pytest.raises(AssertionError)),
+            ({Identifier("1")}, set(), {Identifier("1")}, pytest.raises(AssertionError)),
+        ],
+    )
+    def test_local_identifiers_must_be_identical_to_outbound_identifiers(
+        source: set[Identifier], outbound: set[Identifier], local: set[Identifier], expectation: ContextManager[None]
+    ) -> None:
+        with expectation:
+            Link(source=source, outbound=outbound, local=local)
+
+
+class TestTransfer:
+    @staticmethod
+    @pytest.mark.parametrize(
+        "origin,expectation",
+        [
+            (Components.SOURCE, does_not_raise()),
+            (Components.OUTBOUND, pytest.raises(AssertionError)),
+            (Components.LOCAL, pytest.raises(AssertionError)),
+        ],
+    )
+    def test_origin_must_be_source(origin: Components, expectation: ContextManager[None]) -> None:
+        with expectation:
+            Transfer(Identifier("1"), origin, Components.LOCAL, identifier_only=False)
+
+    @staticmethod
+    @pytest.mark.parametrize(
+        "destination,identifier_only,expectation",
+        [
+            (Components.SOURCE, False, pytest.raises(AssertionError)),
+            (Components.OUTBOUND, True, does_not_raise()),
+            (Components.LOCAL, False, does_not_raise()),
+        ],
+    )
+    def test_destination_must_be_outbound_or_local(
+        destination: Components, identifier_only: bool, expectation: ContextManager[None]
+    ) -> None:
+        with expectation:
+            Transfer(Identifier("1"), Components.SOURCE, destination, identifier_only)
+
+    @staticmethod
+    @pytest.mark.parametrize(
+        "destination,identifier_only,expectation",
+        [
+            (Components.OUTBOUND, False, pytest.raises(AssertionError)),
+            (Components.LOCAL, False, does_not_raise()),
+            (Components.OUTBOUND, True, does_not_raise()),
+            (Components.LOCAL, True, pytest.raises(AssertionError)),
+        ],
+    )
+    def test_identifier_only_must_be_true_only_if_destination_is_outbound(
+        destination: Components, identifier_only: bool, expectation: ContextManager[None]
+    ) -> None:
+        with expectation:
+            Transfer(Identifier("1"), Components.SOURCE, destination, identifier_only)
+
+
+class TestPull:
+    @staticmethod
+    @pytest.mark.parametrize(
+        "source,requested,expectation",
+        [
+            ({Identifier("1")}, {Identifier("1"), Identifier("2")}, pytest.raises(AssertionError)),
+            ({Identifier("1")}, {Identifier("1")}, does_not_raise()),
+            ({Identifier("1"), Identifier("2")}, {Identifier("1")}, does_not_raise()),
+        ],
+    )
+    def test_requested_identifiers_can_not_be_superset_of_source_identifiers(
+        source: set[Identifier], requested: set[Identifier], expectation: ContextManager[None]
+    ) -> None:
+        link = Link(source=source, outbound=set(), local=set())
+        with expectation:
+            pull(link, requested=requested)
+
+    @staticmethod
+    def test_if_correct_transfer_specifications_are_returned() -> None:
+        link = Link(source={Identifier("1"), Identifier("2")}, outbound=set(), local=set())
+        expected = {
+            Transfer(Identifier("1"), Components.SOURCE, Components.OUTBOUND, identifier_only=True),
+            Transfer(Identifier("1"), Components.SOURCE, Components.LOCAL, identifier_only=False),
+        }
+        actual = pull(link, requested={Identifier("1")})
+        assert actual == expected


### PR DESCRIPTION
This PR adds a new module to the domain. The contained code encapsulates the rules that govern the pulling of entities. Crucially the new code is written using the functional style and does no longer rely on the gateway. The pull use case was also rewritten to make use of the new domain logic.
