### PR TITLE
Add entity and states

### DIFF
--- a/dj_link/entities/link.py
+++ b/dj_link/entities/link.py
@@ -100,6 +100,9 @@ def pull(
 ) -> set[Transfer]:
     """Create the transfer specifications needed for pulling the requested identifiers."""
     assert set(requested) <= {entity.identifier for entity in link.source}, "Requested must not be superset of source."
+    assert all(
+        entity.state is States.IDLE for entity in link.source if entity.identifier in set(requested)
+    ), "Requested entities must be idle."
     outbound_destined = set(requested) - {entity.identifier for entity in link.outbound}
     local_destined = set(requested) - {entity.identifier for entity in link.local}
     outbound_transfers = {

--- a/dj_link/entities/link.py
+++ b/dj_link/entities/link.py
@@ -28,9 +28,9 @@ class Entity:
 def create_link(assignments: Mapping[Components, Iterable[Identifier]]) -> Link:
     """Create a new link instance."""
     return Link(
-        source=set(assignments[Components.SOURCE]),
-        outbound=set(assignments[Components.OUTBOUND]),
-        local=set(assignments[Components.LOCAL]),
+        source={Entity(i) for i in assignments[Components.SOURCE]},
+        outbound={Entity(i) for i in assignments[Components.OUTBOUND]},
+        local={Entity(i) for i in assignments[Components.LOCAL]},
     )
 
 
@@ -38,9 +38,9 @@ def create_link(assignments: Mapping[Components, Iterable[Identifier]]) -> Link:
 class Link:
     """The state of a link between two databases."""
 
-    source: set[Identifier]
-    outbound: set[Identifier]
-    local: set[Identifier]
+    source: set[Entity]
+    outbound: set[Entity]
+    local: set[Entity]
 
     def __post_init__(self) -> None:
         """Validate the created link."""
@@ -73,9 +73,9 @@ def pull(
     requested: Iterable[Identifier],
 ) -> set[Transfer]:
     """Create the transfer specifications needed for pulling the requested identifiers."""
-    assert set(requested) <= link.source, "Requested must not be superset of source."
-    outbound_destined = set(requested) - link.outbound
-    local_destined = set(requested) - link.local
+    assert set(requested) <= {entity.identifier for entity in link.source}, "Requested must not be superset of source."
+    outbound_destined = set(requested) - {entity.identifier for entity in link.outbound}
+    local_destined = set(requested) - {entity.identifier for entity in link.local}
     outbound_transfers = {
         Transfer(i, origin=Components.SOURCE, destination=Components.OUTBOUND, identifier_only=True)
         for i in outbound_destined

--- a/dj_link/entities/link.py
+++ b/dj_link/entities/link.py
@@ -18,6 +18,13 @@ class Components(Enum):
 Identifier = NewType("Identifier", str)
 
 
+@dataclass(frozen=True)
+class Entity:
+    """An entity in a link."""
+
+    identifier: Identifier
+
+
 def create_link(assignments: Mapping[Components, Iterable[Identifier]]) -> Link:
     """Create a new link instance."""
     return Link(

--- a/dj_link/entities/link.py
+++ b/dj_link/entities/link.py
@@ -15,6 +15,13 @@ class Components(Enum):
     LOCAL = 3
 
 
+class States(Enum):
+    """Names for the different states of an entity."""
+
+    IDLE = 1
+    PULLED = 2
+
+
 Identifier = NewType("Identifier", str)
 
 

--- a/dj_link/entities/link.py
+++ b/dj_link/entities/link.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from collections.abc import Iterable
 from dataclasses import dataclass
 from enum import Enum
-from typing import NewType
+from typing import Mapping, NewType
 
 
 class Components(Enum):
@@ -16,6 +16,15 @@ class Components(Enum):
 
 
 Identifier = NewType("Identifier", str)
+
+
+def create_link(assignments: Mapping[Components, Iterable[Identifier]]) -> Link:
+    """Create a new link instance."""
+    return Link(
+        source=set(assignments[Components.SOURCE]),
+        outbound=set(assignments[Components.OUTBOUND]),
+        local=set(assignments[Components.LOCAL]),
+    )
 
 
 @dataclass(frozen=True)

--- a/dj_link/entities/link.py
+++ b/dj_link/entities/link.py
@@ -70,9 +70,9 @@ def create_link(assignments: Mapping[Components, Iterable[Identifier]]) -> Link:
     validate_assignments(assignments)
     entity_assignments = assign_entities(create_entities(assignments))
     return Link(
-        source=entity_assignments[Components.SOURCE],
-        outbound=entity_assignments[Components.OUTBOUND],
-        local=entity_assignments[Components.LOCAL],
+        source=frozenset(entity_assignments[Components.SOURCE]),
+        outbound=frozenset(entity_assignments[Components.OUTBOUND]),
+        local=frozenset(entity_assignments[Components.LOCAL]),
     )
 
 
@@ -80,9 +80,9 @@ def create_link(assignments: Mapping[Components, Iterable[Identifier]]) -> Link:
 class Link:
     """The state of a link between two databases."""
 
-    source: set[Entity]
-    outbound: set[Entity]
-    local: set[Entity]
+    source: frozenset[Entity]
+    outbound: frozenset[Entity]
+    local: frozenset[Entity]
 
 
 @dataclass(frozen=True)

--- a/dj_link/entities/link.py
+++ b/dj_link/entities/link.py
@@ -30,14 +30,15 @@ class Entity:
     """An entity in a link."""
 
     identifier: Identifier
+    state: States
 
 
 def create_link(assignments: Mapping[Components, Iterable[Identifier]]) -> Link:
     """Create a new link instance."""
     return Link(
-        source={Entity(i) for i in assignments[Components.SOURCE]},
-        outbound={Entity(i) for i in assignments[Components.OUTBOUND]},
-        local={Entity(i) for i in assignments[Components.LOCAL]},
+        source={Entity(i, state=States.IDLE) for i in assignments[Components.SOURCE]},
+        outbound={Entity(i, state=States.IDLE) for i in assignments[Components.OUTBOUND]},
+        local={Entity(i, state=States.IDLE) for i in assignments[Components.LOCAL]},
     )
 
 

--- a/dj_link/use_cases/pull.py
+++ b/dj_link/use_cases/pull.py
@@ -5,7 +5,7 @@ import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, List, Set
 
-from ..entities.link import Identifier, Link, pull
+from ..entities.link import Components, Identifier, create_link, pull
 from .base import AbstractRequestModel, AbstractResponseModel, AbstractUseCase
 
 if TYPE_CHECKING:
@@ -54,10 +54,12 @@ class PullUseCase(AbstractUseCase[PullRequestModel, PullResponseModel]):  # pyli
     def execute(self, repo_link: RepositoryLink, request_model: PullRequestModel) -> PullResponseModel:
         """Pull the entities specified by the provided identifiers if they were not already pulled."""
         valid_identifiers = {Identifier(i) for i in request_model.identifiers if i not in self.gateway_link.outbound}
-        link = Link(
-            source={Identifier(i) for i in self.gateway_link.source},
-            outbound={Identifier(i) for i in self.gateway_link.outbound},
-            local={Identifier(i) for i in self.gateway_link.local},
+        link = create_link(
+            {
+                Components.SOURCE: {Identifier(i) for i in self.gateway_link.source},
+                Components.OUTBOUND: {Identifier(i) for i in self.gateway_link.outbound},
+                Components.LOCAL: {Identifier(i) for i in self.gateway_link.local},
+            },
         )
         transfers = pull(link, requested=valid_identifiers)
         for transfer in transfers:

--- a/tests/unit/entities/test_link.py
+++ b/tests/unit/entities/test_link.py
@@ -5,7 +5,17 @@ from typing import ContextManager
 
 import pytest
 
-from dj_link.entities.link import Components, Identifier, Link, Transfer, pull
+from dj_link.entities.link import Components, Identifier, Link, Transfer, create_link, pull
+
+
+def test_can_create_link() -> None:
+    assignments = {
+        Components.SOURCE: {Identifier("1")},
+        Components.OUTBOUND: {Identifier("1")},
+        Components.LOCAL: {Identifier("1")},
+    }
+    link = create_link(assignments)
+    assert link == Link(source={Identifier("1")}, outbound={Identifier("1")}, local={Identifier("1")})
 
 
 class TestLink:

--- a/tests/unit/entities/test_link.py
+++ b/tests/unit/entities/test_link.py
@@ -5,7 +5,7 @@ from typing import ContextManager, Iterable, Mapping
 
 import pytest
 
-from dj_link.entities.link import Components, Identifier, Link, Transfer, create_link, pull
+from dj_link.entities.link import Components, Entity, Identifier, Link, Transfer, create_link, pull
 
 
 class TestCreateLink:
@@ -17,7 +17,9 @@ class TestCreateLink:
             Components.LOCAL: {Identifier("1")},
         }
         link = create_link(assignments)
-        assert link == Link(source={Identifier("1")}, outbound={Identifier("1")}, local={Identifier("1")})
+        assert link == Link(
+            source={Entity(Identifier("1"))}, outbound={Entity(Identifier("1"))}, local={Entity(Identifier("1"))}
+        )
 
     @staticmethod
     @pytest.mark.parametrize(

--- a/tests/unit/entities/test_link.py
+++ b/tests/unit/entities/test_link.py
@@ -5,24 +5,10 @@ from typing import ContextManager, Iterable, Mapping
 
 import pytest
 
-from dj_link.entities.link import Components, Entity, Identifier, Link, States, Transfer, create_link, pull
+from dj_link.entities.link import Components, Identifier, States, Transfer, create_link, pull
 
 
 class TestCreateLink:
-    @staticmethod
-    def test_can_create_link() -> None:
-        assignments = {
-            Components.SOURCE: {Identifier("1")},
-            Components.OUTBOUND: {Identifier("1")},
-            Components.LOCAL: {Identifier("1")},
-        }
-        link = create_link(assignments)
-        assert link == Link(
-            source={Entity(Identifier("1"), state=States.PULLED)},
-            outbound={Entity(Identifier("1"), state=States.PULLED)},
-            local={Entity(Identifier("1"), state=States.PULLED)},
-        )
-
     @staticmethod
     def test_entities_only_present_in_source_are_idle() -> None:
         assignments = {

--- a/tests/unit/entities/test_link.py
+++ b/tests/unit/entities/test_link.py
@@ -5,7 +5,7 @@ from typing import ContextManager, Iterable, Mapping
 
 import pytest
 
-from dj_link.entities.link import Components, Entity, Identifier, Link, Transfer, create_link, pull
+from dj_link.entities.link import Components, Entity, Identifier, Link, States, Transfer, create_link, pull
 
 
 class TestCreateLink:
@@ -18,7 +18,9 @@ class TestCreateLink:
         }
         link = create_link(assignments)
         assert link == Link(
-            source={Entity(Identifier("1"))}, outbound={Entity(Identifier("1"))}, local={Entity(Identifier("1"))}
+            source={Entity(Identifier("1"), state=States.IDLE)},
+            outbound={Entity(Identifier("1"), state=States.IDLE)},
+            local={Entity(Identifier("1"), state=States.IDLE)},
         )
 
     @staticmethod

--- a/tests/unit/entities/test_link.py
+++ b/tests/unit/entities/test_link.py
@@ -164,6 +164,35 @@ class TestPull:
             pull(link, requested=requested)
 
     @staticmethod
+    @pytest.mark.parametrize(
+        "assignments,requested,expectation",
+        [
+            (
+                {
+                    Components.SOURCE: {Identifier("1")},
+                    Components.OUTBOUND: {Identifier("1")},
+                    Components.LOCAL: {Identifier("1")},
+                },
+                {Identifier("1")},
+                pytest.raises(AssertionError),
+            ),
+            (
+                {Components.SOURCE: {Identifier("1")}, Components.OUTBOUND: set(), Components.LOCAL: set()},
+                {Identifier("1")},
+                does_not_raise(),
+            ),
+        ],
+    )
+    def test_can_not_pull_already_pulled_entities(
+        assignments: Mapping[Components, Iterable[Identifier]],
+        requested: Iterable[Identifier],
+        expectation: ContextManager[None],
+    ) -> None:
+        link = create_link(assignments)
+        with expectation:
+            pull(link, requested=requested)
+
+    @staticmethod
     def test_if_correct_transfer_specifications_are_returned() -> None:
         link = create_link(
             {Components.SOURCE: {Identifier("1"), Identifier("2")}, Components.OUTBOUND: set(), Components.LOCAL: set()}

--- a/tests/unit/entities/test_link.py
+++ b/tests/unit/entities/test_link.py
@@ -8,17 +8,17 @@ import pytest
 from dj_link.entities.link import Components, Identifier, Link, Transfer, create_link, pull
 
 
-def test_can_create_link() -> None:
-    assignments = {
-        Components.SOURCE: {Identifier("1")},
-        Components.OUTBOUND: {Identifier("1")},
-        Components.LOCAL: {Identifier("1")},
-    }
-    link = create_link(assignments)
-    assert link == Link(source={Identifier("1")}, outbound={Identifier("1")}, local={Identifier("1")})
-
-
 class TestCreateLink:
+    @staticmethod
+    def test_can_create_link() -> None:
+        assignments = {
+            Components.SOURCE: {Identifier("1")},
+            Components.OUTBOUND: {Identifier("1")},
+            Components.LOCAL: {Identifier("1")},
+        }
+        link = create_link(assignments)
+        assert link == Link(source={Identifier("1")}, outbound={Identifier("1")}, local={Identifier("1")})
+
     @staticmethod
     @pytest.mark.parametrize(
         "assignments,expectation",

--- a/tests/unit/entities/test_link.py
+++ b/tests/unit/entities/test_link.py
@@ -34,6 +34,16 @@ class TestCreateLink:
         assert {entity.identifier for entity in link.source if entity.state is States.IDLE} == {Identifier("2")}
 
     @staticmethod
+    def test_entities_present_in_all_components_are_pulled() -> None:
+        assignments = {
+            Components.SOURCE: {Identifier("1"), Identifier("2")},
+            Components.OUTBOUND: {Identifier("1")},
+            Components.LOCAL: {Identifier("1")},
+        }
+        link = create_link(assignments)
+        assert {entity.identifier for entity in link.source if entity.state is States.PULLED} == {Identifier("1")}
+
+    @staticmethod
     @pytest.mark.parametrize(
         "assignments,expectation",
         [

--- a/tests/unit/entities/test_link.py
+++ b/tests/unit/entities/test_link.py
@@ -18,14 +18,20 @@ class TestCreateLink:
         }
         link = create_link(assignments)
         assert link == Link(
-            source={Entity(Identifier("1"), state=States.IDLE)},
-            outbound={Entity(Identifier("1"), state=States.IDLE)},
-            local={Entity(Identifier("1"), state=States.IDLE)},
+            source={Entity(Identifier("1"), state=States.PULLED)},
+            outbound={Entity(Identifier("1"), state=States.PULLED)},
+            local={Entity(Identifier("1"), state=States.PULLED)},
         )
 
     @staticmethod
-    def test_idle_entities_can_only_be_in_source() -> None:
-        pass
+    def test_entities_only_present_in_source_are_idle() -> None:
+        assignments = {
+            Components.SOURCE: {Identifier("1"), Identifier("2")},
+            Components.OUTBOUND: {Identifier("1")},
+            Components.LOCAL: {Identifier("1")},
+        }
+        link = create_link(assignments)
+        assert {entity.identifier for entity in link.source if entity.state is States.IDLE} == {Identifier("2")}
 
     @staticmethod
     @pytest.mark.parametrize(

--- a/tests/unit/entities/test_link.py
+++ b/tests/unit/entities/test_link.py
@@ -22,6 +22,10 @@ class TestCreateLink:
         )
 
     @staticmethod
+    def test_idle_entities_can_only_be_in_source() -> None:
+        pass
+
+    @staticmethod
     @pytest.mark.parametrize(
         "assignments,expectation",
         [

--- a/tests/unit/entities/test_link.py
+++ b/tests/unit/entities/test_link.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from contextlib import nullcontext as does_not_raise
-from typing import ContextManager
+from typing import ContextManager, Iterable, Mapping
 
 import pytest
 
@@ -18,36 +18,55 @@ def test_can_create_link() -> None:
     assert link == Link(source={Identifier("1")}, outbound={Identifier("1")}, local={Identifier("1")})
 
 
-class TestLink:
+class TestCreateLink:
     @staticmethod
     @pytest.mark.parametrize(
-        "source,outbound,local,expectation",
+        "assignments,expectation",
         [
-            (set(), {Identifier("1")}, {Identifier("1")}, pytest.raises(AssertionError)),
-            (set(), set(), set(), does_not_raise()),
-            ({Identifier("1")}, set(), set(), does_not_raise()),
+            (
+                {Components.SOURCE: set(), Components.OUTBOUND: {Identifier("1")}, Components.LOCAL: {Identifier("1")}},
+                pytest.raises(AssertionError),
+            ),
+            ({Components.SOURCE: set(), Components.OUTBOUND: set(), Components.LOCAL: set()}, does_not_raise()),
+            (
+                {Components.SOURCE: {Identifier("1")}, Components.OUTBOUND: set(), Components.LOCAL: set()},
+                does_not_raise(),
+            ),
         ],
     )
     def test_outbound_identifiers_can_not_be_superset_of_source_identifiers(
-        source: set[Identifier], outbound: set[Identifier], local: set[Identifier], expectation: ContextManager[None]
+        assignments: Mapping[Components, Iterable[Identifier]], expectation: ContextManager[None]
     ) -> None:
         with expectation:
-            Link(source=source, outbound=outbound, local=local)
+            create_link(assignments)
 
     @staticmethod
     @pytest.mark.parametrize(
-        "source,outbound,local,expectation",
+        "assignments,expectation",
         [
-            ({Identifier("1")}, {Identifier("1")}, {Identifier("1")}, does_not_raise()),
-            ({Identifier("1")}, {Identifier("1")}, set(), pytest.raises(AssertionError)),
-            ({Identifier("1")}, set(), {Identifier("1")}, pytest.raises(AssertionError)),
+            (
+                {
+                    Components.SOURCE: {Identifier("1")},
+                    Components.OUTBOUND: {Identifier("1")},
+                    Components.LOCAL: {Identifier("1")},
+                },
+                does_not_raise(),
+            ),
+            (
+                {Components.SOURCE: {Identifier("1")}, Components.OUTBOUND: {Identifier("1")}, Components.LOCAL: set()},
+                pytest.raises(AssertionError),
+            ),
+            (
+                {Components.SOURCE: {Identifier("1")}, Components.OUTBOUND: set(), Components.LOCAL: {Identifier("1")}},
+                pytest.raises(AssertionError),
+            ),
         ],
     )
     def test_local_identifiers_must_be_identical_to_outbound_identifiers(
-        source: set[Identifier], outbound: set[Identifier], local: set[Identifier], expectation: ContextManager[None]
+        assignments: Mapping[Components, Iterable[Identifier]], expectation: ContextManager[None]
     ) -> None:
         with expectation:
-            Link(source=source, outbound=outbound, local=local)
+            create_link(assignments)
 
 
 class TestTransfer:
@@ -99,23 +118,43 @@ class TestTransfer:
 class TestPull:
     @staticmethod
     @pytest.mark.parametrize(
-        "source,requested,expectation",
+        "assignments,requested,expectation",
         [
-            ({Identifier("1")}, {Identifier("1"), Identifier("2")}, pytest.raises(AssertionError)),
-            ({Identifier("1")}, {Identifier("1")}, does_not_raise()),
-            ({Identifier("1"), Identifier("2")}, {Identifier("1")}, does_not_raise()),
+            (
+                {Components.SOURCE: {Identifier("1")}, Components.OUTBOUND: set(), Components.LOCAL: set()},
+                {Identifier("1"), Identifier("2")},
+                pytest.raises(AssertionError),
+            ),
+            (
+                {Components.SOURCE: {Identifier("1")}, Components.OUTBOUND: set(), Components.LOCAL: set()},
+                {Identifier("1")},
+                does_not_raise(),
+            ),
+            (
+                {
+                    Components.SOURCE: {Identifier("1"), Identifier("2")},
+                    Components.OUTBOUND: set(),
+                    Components.LOCAL: set(),
+                },
+                {Identifier("1")},
+                does_not_raise(),
+            ),
         ],
     )
     def test_requested_identifiers_can_not_be_superset_of_source_identifiers(
-        source: set[Identifier], requested: set[Identifier], expectation: ContextManager[None]
+        assignments: Mapping[Components, Iterable[Identifier]],
+        requested: set[Identifier],
+        expectation: ContextManager[None],
     ) -> None:
-        link = Link(source=source, outbound=set(), local=set())
+        link = create_link(assignments)
         with expectation:
             pull(link, requested=requested)
 
     @staticmethod
     def test_if_correct_transfer_specifications_are_returned() -> None:
-        link = Link(source={Identifier("1"), Identifier("2")}, outbound=set(), local=set())
+        link = create_link(
+            {Components.SOURCE: {Identifier("1"), Identifier("2")}, Components.OUTBOUND: set(), Components.LOCAL: set()}
+        )
         expected = {
             Transfer(Identifier("1"), Components.SOURCE, Components.OUTBOUND, identifier_only=True),
             Transfer(Identifier("1"), Components.SOURCE, Components.LOCAL, identifier_only=False),


### PR DESCRIPTION
An entity contains an identifier and a state. The state can for now either be
'idle' or 'pulled'. Idle entities are only present in the source component of
the link and can be pulled. Pulled entities are present in all components and
can not be pulled. Idle entities become pulled entities when they are pulled.
Pulled entities can not become idle again.
A link now contains entities instead of identifiers.
