### PR TITLE
Add component class

### DIFF
--- a/dj_link/entities/link.py
+++ b/dj_link/entities/link.py
@@ -128,14 +128,12 @@ def pull(
     requested: Iterable[Identifier],
 ) -> set[Transfer]:
     """Create the transfer specifications needed for pulling the requested identifiers."""
-    assert set(requested) <= {
-        entity.identifier for entity in link[Components.SOURCE]
-    }, "Requested must not be superset of source."
+    assert set(requested) <= link[Components.SOURCE].identifiers, "Requested must not be superset of source."
     assert all(
         entity.state is States.IDLE for entity in link[Components.SOURCE] if entity.identifier in set(requested)
     ), "Requested entities must be idle."
-    outbound_destined = set(requested) - {entity.identifier for entity in link[Components.OUTBOUND]}
-    local_destined = set(requested) - {entity.identifier for entity in link[Components.LOCAL]}
+    outbound_destined = set(requested) - link[Components.OUTBOUND].identifiers
+    local_destined = set(requested) - link[Components.LOCAL].identifiers
     outbound_transfers = {
         Transfer(i, origin=Components.SOURCE, destination=Components.OUTBOUND, identifier_only=True)
         for i in outbound_destined

--- a/dj_link/entities/link.py
+++ b/dj_link/entities/link.py
@@ -84,6 +84,15 @@ class Link:
     outbound: frozenset[Entity]
     local: frozenset[Entity]
 
+    def __getitem__(self, component: Components) -> frozenset[Entity]:
+        """Return the entities in the given component."""
+        component_map = {
+            Components.SOURCE: self.source,
+            Components.OUTBOUND: self.outbound,
+            Components.LOCAL: self.local,
+        }
+        return component_map[component]
+
 
 @dataclass(frozen=True)
 class Transfer:

--- a/dj_link/entities/link.py
+++ b/dj_link/entities/link.py
@@ -5,7 +5,7 @@ from collections.abc import Iterable
 from dataclasses import dataclass
 from enum import Enum
 from functools import reduce
-from typing import Mapping, NewType
+from typing import FrozenSet, Mapping, NewType
 
 
 class Components(Enum):
@@ -70,9 +70,9 @@ def create_link(assignments: Mapping[Components, Iterable[Identifier]]) -> Link:
     validate_assignments(assignments)
     entity_assignments = assign_entities(create_entities(assignments))
     return Link(
-        source=frozenset(entity_assignments[Components.SOURCE]),
-        outbound=frozenset(entity_assignments[Components.OUTBOUND]),
-        local=frozenset(entity_assignments[Components.LOCAL]),
+        source=Component(entity_assignments[Components.SOURCE]),
+        outbound=Component(entity_assignments[Components.OUTBOUND]),
+        local=Component(entity_assignments[Components.LOCAL]),
     )
 
 
@@ -80,11 +80,11 @@ def create_link(assignments: Mapping[Components, Iterable[Identifier]]) -> Link:
 class Link:
     """The state of a link between two databases."""
 
-    source: frozenset[Entity]
-    outbound: frozenset[Entity]
-    local: frozenset[Entity]
+    source: Component
+    outbound: Component
+    local: Component
 
-    def __getitem__(self, component: Components) -> frozenset[Entity]:
+    def __getitem__(self, component: Components) -> Component:
         """Return the entities in the given component."""
         component_map = {
             Components.SOURCE: self.source,
@@ -92,6 +92,15 @@ class Link:
             Components.LOCAL: self.local,
         }
         return component_map[component]
+
+
+class Component(FrozenSet[Entity]):
+    """Contains all entities present in a component."""
+
+    @property
+    def identifiers(self) -> frozenset[Identifier]:
+        """Return all identifiers of entities in the component."""
+        return frozenset(entity.identifier for entity in self)
 
 
 @dataclass(frozen=True)
@@ -119,12 +128,14 @@ def pull(
     requested: Iterable[Identifier],
 ) -> set[Transfer]:
     """Create the transfer specifications needed for pulling the requested identifiers."""
-    assert set(requested) <= {entity.identifier for entity in link.source}, "Requested must not be superset of source."
+    assert set(requested) <= {
+        entity.identifier for entity in link[Components.SOURCE]
+    }, "Requested must not be superset of source."
     assert all(
-        entity.state is States.IDLE for entity in link.source if entity.identifier in set(requested)
+        entity.state is States.IDLE for entity in link[Components.SOURCE] if entity.identifier in set(requested)
     ), "Requested entities must be idle."
-    outbound_destined = set(requested) - {entity.identifier for entity in link.outbound}
-    local_destined = set(requested) - {entity.identifier for entity in link.local}
+    outbound_destined = set(requested) - {entity.identifier for entity in link[Components.OUTBOUND]}
+    local_destined = set(requested) - {entity.identifier for entity in link[Components.LOCAL]}
     outbound_transfers = {
         Transfer(i, origin=Components.SOURCE, destination=Components.OUTBOUND, identifier_only=True)
         for i in outbound_destined

--- a/tests/unit/entities/test_link.py
+++ b/tests/unit/entities/test_link.py
@@ -5,7 +5,7 @@ from typing import ContextManager, Iterable, Mapping
 
 import pytest
 
-from dj_link.entities.link import Components, Entity, Identifier, States, Transfer, create_link, pull
+from dj_link.entities.link import Component, Components, Entity, Identifier, States, Transfer, create_link, pull
 
 
 class TestCreateLink:
@@ -30,7 +30,7 @@ class TestCreateLink:
         assignments: Mapping[Components, Iterable[Identifier]], state: States, expected: Iterable[Identifier]
     ) -> None:
         link = create_link(assignments)
-        assert {entity.identifier for entity in link.source if entity.state is state} == set(expected)
+        assert {entity.identifier for entity in link[Components.SOURCE] if entity.state is state} == set(expected)
 
     @staticmethod
     @pytest.mark.parametrize(
@@ -89,9 +89,19 @@ def test_can_get_entities_in_component() -> None:
         Components.LOCAL: {Identifier("1")},
     }
     link = create_link(assignments)
-    assert link[Components.SOURCE] == frozenset(
+    assert link[Components.SOURCE] == Component(
         {Entity(Identifier("1"), state=States.PULLED), Entity(Identifier("2"), state=States.IDLE)}
     )
+
+
+def test_can_get_identifiers_of_entities_in_component() -> None:
+    assignments = {
+        Components.SOURCE: {Identifier("1"), Identifier("2")},
+        Components.OUTBOUND: {Identifier("1")},
+        Components.LOCAL: {Identifier("1")},
+    }
+    link = create_link(assignments)
+    assert link[Components.SOURCE].identifiers == frozenset({Identifier("1"), Identifier("2")})
 
 
 class TestTransfer:

--- a/tests/unit/entities/test_link.py
+++ b/tests/unit/entities/test_link.py
@@ -82,26 +82,28 @@ class TestCreateLink:
             create_link(assignments)
 
 
-def test_can_get_entities_in_component() -> None:
-    assignments = {
-        Components.SOURCE: {Identifier("1"), Identifier("2")},
-        Components.OUTBOUND: {Identifier("1")},
-        Components.LOCAL: {Identifier("1")},
-    }
-    link = create_link(assignments)
-    assert link[Components.SOURCE] == Component(
-        {Entity(Identifier("1"), state=States.PULLED), Entity(Identifier("2"), state=States.IDLE)}
-    )
+class TestLink:
+    @staticmethod
+    def test_can_get_entities_in_component() -> None:
+        assignments = {
+            Components.SOURCE: {Identifier("1"), Identifier("2")},
+            Components.OUTBOUND: {Identifier("1")},
+            Components.LOCAL: {Identifier("1")},
+        }
+        link = create_link(assignments)
+        assert link[Components.SOURCE] == Component(
+            {Entity(Identifier("1"), state=States.PULLED), Entity(Identifier("2"), state=States.IDLE)}
+        )
 
-
-def test_can_get_identifiers_of_entities_in_component() -> None:
-    assignments = {
-        Components.SOURCE: {Identifier("1"), Identifier("2")},
-        Components.OUTBOUND: {Identifier("1")},
-        Components.LOCAL: {Identifier("1")},
-    }
-    link = create_link(assignments)
-    assert link[Components.SOURCE].identifiers == frozenset({Identifier("1"), Identifier("2")})
+    @staticmethod
+    def test_can_get_identifiers_of_entities_in_component() -> None:
+        assignments = {
+            Components.SOURCE: {Identifier("1"), Identifier("2")},
+            Components.OUTBOUND: {Identifier("1")},
+            Components.LOCAL: {Identifier("1")},
+        }
+        link = create_link(assignments)
+        assert link[Components.SOURCE].identifiers == frozenset({Identifier("1"), Identifier("2")})
 
 
 class TestTransfer:

--- a/tests/unit/entities/test_link.py
+++ b/tests/unit/entities/test_link.py
@@ -84,12 +84,16 @@ class TestCreateLink:
 
 class TestLink:
     @staticmethod
-    def test_can_get_entities_in_component() -> None:
-        assignments = {
+    @pytest.fixture
+    def assignments() -> dict[Components, set[Identifier]]:
+        return {
             Components.SOURCE: {Identifier("1"), Identifier("2")},
             Components.OUTBOUND: {Identifier("1")},
             Components.LOCAL: {Identifier("1")},
         }
+
+    @staticmethod
+    def test_can_get_entities_in_component(assignments: Mapping[Components, Iterable[Identifier]]) -> None:
         link = create_link(assignments)
         assert set(link[Components.SOURCE]) == {
             Entity(Identifier("1"), state=States.PULLED),
@@ -97,12 +101,9 @@ class TestLink:
         }
 
     @staticmethod
-    def test_can_get_identifiers_of_entities_in_component() -> None:
-        assignments = {
-            Components.SOURCE: {Identifier("1"), Identifier("2")},
-            Components.OUTBOUND: {Identifier("1")},
-            Components.LOCAL: {Identifier("1")},
-        }
+    def test_can_get_identifiers_of_entities_in_component(
+        assignments: Mapping[Components, Iterable[Identifier]]
+    ) -> None:
         link = create_link(assignments)
         assert set(link[Components.SOURCE].identifiers) == {Identifier("1"), Identifier("2")}
 

--- a/tests/unit/entities/test_link.py
+++ b/tests/unit/entities/test_link.py
@@ -5,7 +5,7 @@ from typing import ContextManager, Iterable, Mapping
 
 import pytest
 
-from dj_link.entities.link import Component, Components, Entity, Identifier, States, Transfer, create_link, pull
+from dj_link.entities.link import Components, Entity, Identifier, States, Transfer, create_link, pull
 
 
 class TestCreateLink:
@@ -91,9 +91,10 @@ class TestLink:
             Components.LOCAL: {Identifier("1")},
         }
         link = create_link(assignments)
-        assert link[Components.SOURCE] == Component(
-            {Entity(Identifier("1"), state=States.PULLED), Entity(Identifier("2"), state=States.IDLE)}
-        )
+        assert set(link[Components.SOURCE]) == {
+            Entity(Identifier("1"), state=States.PULLED),
+            Entity(Identifier("2"), state=States.IDLE),
+        }
 
     @staticmethod
     def test_can_get_identifiers_of_entities_in_component() -> None:
@@ -103,7 +104,7 @@ class TestLink:
             Components.LOCAL: {Identifier("1")},
         }
         link = create_link(assignments)
-        assert link[Components.SOURCE].identifiers == frozenset({Identifier("1"), Identifier("2")})
+        assert set(link[Components.SOURCE].identifiers) == {Identifier("1"), Identifier("2")}
 
 
 class TestTransfer:

--- a/tests/unit/entities/test_link.py
+++ b/tests/unit/entities/test_link.py
@@ -5,7 +5,7 @@ from typing import ContextManager, Iterable, Mapping
 
 import pytest
 
-from dj_link.entities.link import Components, Identifier, States, Transfer, create_link, pull
+from dj_link.entities.link import Components, Entity, Identifier, States, Transfer, create_link, pull
 
 
 class TestCreateLink:
@@ -80,6 +80,18 @@ class TestCreateLink:
     ) -> None:
         with expectation:
             create_link(assignments)
+
+
+def test_can_get_entities_in_component() -> None:
+    assignments = {
+        Components.SOURCE: {Identifier("1"), Identifier("2")},
+        Components.OUTBOUND: {Identifier("1")},
+        Components.LOCAL: {Identifier("1")},
+    }
+    link = create_link(assignments)
+    assert link[Components.SOURCE] == frozenset(
+        {Entity(Identifier("1"), state=States.PULLED), Entity(Identifier("2"), state=States.IDLE)}
+    )
 
 
 class TestTransfer:


### PR DESCRIPTION
The component class is a wrapper around a frozenset which contains entities. It
has currently one additional method which allows the retrieval of all
identifiers of all entities in the component.

For example now one can write the following to get all identifiers of entities
in the outbound component:
```python
link[Components.OUTBOUND].identifiers
```

Prior to these changes the same query looked like this:
```python
frozenset(entity.identifier for entity in link.outbound)
```
