### PR TITLE
Add ability to mark entities as tainted

### DIFF
--- a/dj_link/entities/link.py
+++ b/dj_link/entities/link.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 from collections.abc import Iterable
 from dataclasses import dataclass
 from enum import Enum
-from functools import reduce
 from typing import FrozenSet, Mapping, NewType, Optional
 
 
@@ -54,9 +53,6 @@ def create_link(
     def create_entities(
         assignments: Mapping[Components, Iterable[Identifier]], tainted: Iterable[Identifier]
     ) -> set[Entity]:
-        def create_identifier_union(assignments: Mapping[Components, Iterable[Identifier]]) -> Iterable[Identifier]:
-            return reduce(lambda x, y: set(x) | set(y), assignments.values())
-
         def create_entity(identifier: Identifier) -> Entity:
             presence = frozenset(
                 component for component, identifiers in assignments.items() if identifier in identifiers
@@ -71,7 +67,7 @@ def create_link(
             frozenset({Components.SOURCE}): States.IDLE,
             frozenset({Components.SOURCE, Components.OUTBOUND, Components.LOCAL}): States.PULLED,
         }
-        return {create_entity(identifier) for identifier in create_identifier_union(assignments)}
+        return {create_entity(identifier) for identifier in assignments[Components.SOURCE]}
 
     def assign_entities(entities: Iterable[Entity]) -> dict[Components, set[Entity]]:
         def assign_to_component(component: Components) -> set[Entity]:

--- a/dj_link/entities/link.py
+++ b/dj_link/entities/link.py
@@ -40,13 +40,16 @@ def create_link(
 ) -> Link:
     """Create a new link instance."""
 
-    def validate_assignments(assignments: Mapping[Components, Iterable[Identifier]]) -> None:
+    def validate_assignments(
+        assignments: Mapping[Components, Iterable[Identifier]], tainted: Iterable[Identifier]
+    ) -> None:
         assert set(assignments[Components.OUTBOUND]) <= set(
             assignments[Components.SOURCE]
         ), "Outbound must not be superset of source."
         assert set(assignments[Components.LOCAL]) == set(
             assignments[Components.OUTBOUND]
         ), "Local and outbound must be identical."
+        assert set(tainted) <= set(assignments[Components.SOURCE])
 
     def create_entities(
         assignments: Mapping[Components, Iterable[Identifier]], tainted: Iterable[Identifier]
@@ -76,9 +79,9 @@ def create_link(
 
         return {component: assign_to_component(component) for component in Components}
 
-    validate_assignments(assignments)
     if tainted is None:
         tainted = set()
+    validate_assignments(assignments, tainted)
     entity_assignments = assign_entities(create_entities(assignments, tainted))
     return Link(
         source=Component(entity_assignments[Components.SOURCE]),

--- a/dj_link/entities/link.py
+++ b/dj_link/entities/link.py
@@ -55,12 +55,14 @@ def create_link(
             return reduce(lambda x, y: set(x) | set(y), assignments.values())
 
         def create_entity(identifier: Identifier) -> Entity:
-            if identifier in tainted:
-                return Entity(identifier, state=States.TAINTED)
             presence = frozenset(
                 component for component, identifiers in assignments.items() if identifier in identifiers
             )
-            return Entity(identifier, state=presence_map[presence])
+            state = presence_map[presence]
+            if identifier in tainted:
+                assert state == States.PULLED, "Only pulled entities can be tainted."
+                return Entity(identifier, state=States.TAINTED)
+            return Entity(identifier, state=state)
 
         presence_map = {
             frozenset({Components.SOURCE}): States.IDLE,

--- a/tests/unit/entities/test_link.py
+++ b/tests/unit/entities/test_link.py
@@ -11,32 +11,23 @@ from dj_link.entities.link import Components, Entity, Identifier, States, Transf
 class TestCreateLink:
     @staticmethod
     @pytest.mark.parametrize(
-        "state,expected",
+        "tainted,state,expected",
         [
-            (States.IDLE, {Identifier("2")}),
-            (States.PULLED, {Identifier("1")}),
+            (set(), States.IDLE, {Identifier("2")}),
+            (set(), States.PULLED, {Identifier("1")}),
+            ({Identifier("1")}, States.TAINTED, {Identifier("1")}),
         ],
     )
-    def test_entities_get_correct_state_assigned(state: States, expected: Iterable[Identifier]) -> None:
+    def test_entities_get_correct_state_assigned(
+        tainted: Iterable[Identifier], state: States, expected: Iterable[Identifier]
+    ) -> None:
         assignments = {
             Components.SOURCE: {Identifier("1"), Identifier("2")},
             Components.OUTBOUND: {Identifier("1")},
             Components.LOCAL: {Identifier("1")},
         }
-        link = create_link(assignments)
+        link = create_link(assignments, tainted=tainted)
         assert {entity.identifier for entity in link[Components.SOURCE] if entity.state is state} == set(expected)
-
-    @staticmethod
-    def test_tainted_entities_get_correct_state_assigned() -> None:
-        assignments = {
-            Components.SOURCE: {Identifier("1"), Identifier("2"), Identifier("3")},
-            Components.OUTBOUND: {Identifier("1"), Identifier("3")},
-            Components.LOCAL: {Identifier("1"), Identifier("3")},
-        }
-        link = create_link(assignments, tainted={Identifier("3")})
-        assert {entity.identifier for entity in link[Components.SOURCE] if entity.state is States.TAINTED} == {
-            Identifier("3")
-        }
 
     @staticmethod
     @pytest.mark.parametrize(

--- a/tests/unit/entities/test_link.py
+++ b/tests/unit/entities/test_link.py
@@ -67,6 +67,38 @@ class TestCreateLink:
         "assignments,expectation",
         [
             (
+                {Components.SOURCE: set(), Components.OUTBOUND: set(), Components.LOCAL: set()},
+                pytest.raises(AssertionError),
+            ),
+            (
+                {
+                    Components.SOURCE: {Identifier("1")},
+                    Components.OUTBOUND: {Identifier("1")},
+                    Components.LOCAL: {Identifier("1")},
+                },
+                does_not_raise(),
+            ),
+            (
+                {
+                    Components.SOURCE: {Identifier("1"), Identifier("2")},
+                    Components.OUTBOUND: {Identifier("1"), Identifier("2")},
+                    Components.LOCAL: {Identifier("1"), Identifier("2")},
+                },
+                does_not_raise(),
+            ),
+        ],
+    )
+    def test_tainted_identifiers_can_not_be_superset_of_source_identifiers(
+        assignments: Mapping[Components, Iterable[Identifier]], expectation: ContextManager[None]
+    ) -> None:
+        with expectation:
+            create_link(assignments, tainted={Identifier("1")})
+
+    @staticmethod
+    @pytest.mark.parametrize(
+        "assignments,expectation",
+        [
+            (
                 {Components.SOURCE: set(), Components.OUTBOUND: {Identifier("1")}, Components.LOCAL: {Identifier("1")}},
                 pytest.raises(AssertionError),
             ),

--- a/tests/unit/entities/test_link.py
+++ b/tests/unit/entities/test_link.py
@@ -43,6 +43,30 @@ class TestCreateLink:
         "assignments,expectation",
         [
             (
+                {Components.SOURCE: {Identifier("1")}, Components.OUTBOUND: set(), Components.LOCAL: set()},
+                pytest.raises(AssertionError),
+            ),
+            (
+                {
+                    Components.SOURCE: {Identifier("1")},
+                    Components.OUTBOUND: {Identifier("1")},
+                    Components.LOCAL: {Identifier("1")},
+                },
+                does_not_raise(),
+            ),
+        ],
+    )
+    def test_only_pulled_entities_can_be_tainted(
+        assignments: Mapping[Components, Iterable[Identifier]], expectation: ContextManager[None]
+    ) -> None:
+        with expectation:
+            create_link(assignments, tainted={Identifier("1")})
+
+    @staticmethod
+    @pytest.mark.parametrize(
+        "assignments,expectation",
+        [
+            (
                 {Components.SOURCE: set(), Components.OUTBOUND: {Identifier("1")}, Components.LOCAL: {Identifier("1")}},
                 pytest.raises(AssertionError),
             ),

--- a/tests/unit/entities/test_link.py
+++ b/tests/unit/entities/test_link.py
@@ -27,6 +27,18 @@ class TestCreateLink:
         assert {entity.identifier for entity in link[Components.SOURCE] if entity.state is state} == set(expected)
 
     @staticmethod
+    def test_tainted_entities_get_correct_state_assigned() -> None:
+        assignments = {
+            Components.SOURCE: {Identifier("1"), Identifier("2"), Identifier("3")},
+            Components.OUTBOUND: {Identifier("1"), Identifier("3")},
+            Components.LOCAL: {Identifier("1"), Identifier("3")},
+        }
+        link = create_link(assignments, tainted={Identifier("3")})
+        assert {entity.identifier for entity in link[Components.SOURCE] if entity.state is States.TAINTED} == {
+            Identifier("3")
+        }
+
+    @staticmethod
     @pytest.mark.parametrize(
         "assignments,expectation",
         [

--- a/tests/unit/entities/test_link.py
+++ b/tests/unit/entities/test_link.py
@@ -10,15 +10,6 @@ from dj_link.entities.link import Components, Entity, Identifier, States, Transf
 
 class TestCreateLink:
     @staticmethod
-    @pytest.fixture
-    def assignments() -> dict[Components, set[Identifier]]:
-        return {
-            Components.SOURCE: {Identifier("1"), Identifier("2")},
-            Components.OUTBOUND: {Identifier("1")},
-            Components.LOCAL: {Identifier("1")},
-        }
-
-    @staticmethod
     @pytest.mark.parametrize(
         "state,expected",
         [
@@ -26,9 +17,12 @@ class TestCreateLink:
             (States.PULLED, {Identifier("1")}),
         ],
     )
-    def test_entities_get_correct_state_assigned(
-        assignments: Mapping[Components, Iterable[Identifier]], state: States, expected: Iterable[Identifier]
-    ) -> None:
+    def test_entities_get_correct_state_assigned(state: States, expected: Iterable[Identifier]) -> None:
+        assignments = {
+            Components.SOURCE: {Identifier("1"), Identifier("2")},
+            Components.OUTBOUND: {Identifier("1")},
+            Components.LOCAL: {Identifier("1")},
+        }
         link = create_link(assignments)
         assert {entity.identifier for entity in link[Components.SOURCE] if entity.state is state} == set(expected)
 

--- a/tests/unit/entities/test_link.py
+++ b/tests/unit/entities/test_link.py
@@ -1,11 +1,27 @@
 from __future__ import annotations
 
 from contextlib import nullcontext as does_not_raise
-from typing import ContextManager, Iterable, Mapping
+from typing import ContextManager, Iterable, Mapping, Optional
 
 import pytest
 
 from dj_link.entities.link import Components, Entity, Identifier, States, Transfer, create_link, pull
+
+
+def create_assignments(
+    assignments: Optional[Mapping[Components, Iterable[str]]] = None
+) -> dict[Components, set[Identifier]]:
+    if assignments is None:
+        assignments = {}
+    else:
+        assignments = dict(assignments)
+    for component in Components:
+        if component not in assignments:
+            assignments[component] = set()
+    return {
+        component: {Identifier(identifier) for identifier in identifiers}
+        for component, identifiers in assignments.items()
+    }
 
 
 class TestCreateLink:


### PR DESCRIPTION
Entities can now be marked as tainted. Tainted entities are faulty and should be deprecated (i.e. deleted) from the local component of the link. Only pulled entities can be tainted.
