### PR TITLE
Add more entity states

### DIFF
--- a/dj_link/entities/link.py
+++ b/dj_link/entities/link.py
@@ -77,7 +77,7 @@ STATE_MAP = {
 def create_link(
     assignments: Mapping[Components, Iterable[Identifier]],
     *,
-    tainted: Optional[Iterable[Identifier]] = None,
+    tainted_identifiers: Optional[Iterable[Identifier]] = None,
     transiting_identifiers: Optional[Iterable[Identifier]] = None,
 ) -> Link:
     """Create a new link instance."""
@@ -119,12 +119,12 @@ def create_link(
 
         return {component: assign_to_component(component) for component in Components}
 
-    if tainted is None:
-        tainted = set()
+    if tainted_identifiers is None:
+        tainted_identifiers = set()
     if transiting_identifiers is None:
         transiting_identifiers = set()
-    validate_assignments(assignments, tainted)
-    entity_assignments = assign_entities(create_entities(assignments, tainted, transiting_identifiers))
+    validate_assignments(assignments, tainted_identifiers)
+    entity_assignments = assign_entities(create_entities(assignments, tainted_identifiers, transiting_identifiers))
     return Link(
         source=Component(entity_assignments[Components.SOURCE]),
         outbound=Component(entity_assignments[Components.OUTBOUND]),

--- a/dj_link/entities/link.py
+++ b/dj_link/entities/link.py
@@ -19,8 +19,9 @@ class States(Enum):
     """Names for the different states of an entity."""
 
     IDLE = 1
-    PULLED = 2
-    TAINTED = 3
+    ACTIVATED = 2
+    PULLED = 3
+    TAINTED = 4
 
 
 Identifier = NewType("Identifier", str)
@@ -65,6 +66,7 @@ def create_link(
 
         presence_map = {
             frozenset({Components.SOURCE}): States.IDLE,
+            frozenset({Components.SOURCE, Components.OUTBOUND}): States.ACTIVATED,
             frozenset({Components.SOURCE, Components.OUTBOUND, Components.LOCAL}): States.PULLED,
         }
         return {create_entity(identifier) for identifier in assignments[Components.SOURCE]}

--- a/dj_link/entities/link.py
+++ b/dj_link/entities/link.py
@@ -105,11 +105,7 @@ def create_link(
             persistent_state = PersistentState(
                 presence, is_tainted=identifier in tainted, is_transiting=identifier in transiting_identifiers
             )
-            try:
-                state = STATE_MAP[persistent_state]
-            except KeyError as error:
-                raise AssertionError from error
-            return Entity(identifier, state=state)
+            return Entity(identifier, state=STATE_MAP[persistent_state])
 
         return {create_entity(identifier) for identifier in assignments[Components.SOURCE]}
 

--- a/dj_link/entities/link.py
+++ b/dj_link/entities/link.py
@@ -66,6 +66,7 @@ def create_link(
             )
             state = presence_map[presence]
             if identifier in in_transit:
+                assert state == States.PULLED
                 return Entity(identifier, state=States.RECEIVED)
             if identifier in tainted:
                 assert state == States.PULLED, "Only pulled entities can be tainted."

--- a/dj_link/entities/link.py
+++ b/dj_link/entities/link.py
@@ -45,9 +45,9 @@ def create_link(
         assert set(assignments[Components.OUTBOUND]) <= set(
             assignments[Components.SOURCE]
         ), "Outbound must not be superset of source."
-        assert set(assignments[Components.LOCAL]) == set(
+        assert set(assignments[Components.LOCAL]) <= set(
             assignments[Components.OUTBOUND]
-        ), "Local and outbound must be identical."
+        ), "Local must not be superset of source."
         assert set(tainted) <= set(assignments[Components.SOURCE])
 
     def create_entities(

--- a/dj_link/entities/link.py
+++ b/dj_link/entities/link.py
@@ -23,6 +23,7 @@ class States(Enum):
     RECEIVED = 3
     PULLED = 4
     TAINTED = 5
+    DEPRECATED = 6
 
 
 Identifier = NewType("Identifier", str)
@@ -71,6 +72,11 @@ STATE_MAP = {
         is_tainted=True,
         is_transiting=False,
     ): States.TAINTED,
+    PersistentState(
+        frozenset({Components.SOURCE}),
+        is_tainted=True,
+        is_transiting=False,
+    ): States.DEPRECATED,
 }
 
 

--- a/tests/functional/test_pulling/test_pulling.py
+++ b/tests/functional/test_pulling/test_pulling.py
@@ -25,7 +25,7 @@ def test_pulling(prepare_link, create_table, connection_config, databases, confi
         assert actual == expected
 
 
-@pytest.mark.xfail(raises=AssertionError)
+@pytest.mark.xfail(raises=(AssertionError, KeyError))
 def test_can_pull_into_different_local_tables_from_same_source(
     prepare_multiple_links, create_table, databases, connection_config, configured_environment
 ):

--- a/tests/unit/entities/test_link.py
+++ b/tests/unit/entities/test_link.py
@@ -27,35 +27,30 @@ def create_assignments(
 class TestCreateLink:
     @staticmethod
     @pytest.mark.parametrize(
-        "transiting_identifiers,tainted,state,expected",
+        "state,expected",
         [
-            (set({Identifier("3")}), set(), States.IDLE, {Identifier("2")}),
-            (set({Identifier("3")}), set(), States.PULLED, {Identifier("1")}),
-            ({Identifier("3")}, set(), States.ACTIVATED, {Identifier("3")}),
-            (set(Identifier("3")), {Identifier("1")}, States.TAINTED, {Identifier("1")}),
+            (States.IDLE, {Identifier("1")}),
+            (States.ACTIVATED, {Identifier("2")}),
+            (States.RECEIVED, {Identifier("3")}),
+            (States.PULLED, {Identifier("4")}),
+            (States.TAINTED, {Identifier("5")}),
         ],
     )
     def test_entities_get_correct_state_assigned(
-        transiting_identifiers: Iterable[Identifier],
-        tainted: Iterable[Identifier],
         state: States,
         expected: Iterable[Identifier],
     ) -> None:
         assignments = create_assignments(
-            {Components.SOURCE: {"1", "2", "3"}, Components.OUTBOUND: {"1", "3"}, Components.LOCAL: {"1"}}
+            {
+                Components.SOURCE: {"1", "2", "3", "4", "5"},
+                Components.OUTBOUND: {"2", "3", "4", "5"},
+                Components.LOCAL: {"3", "4", "5"},
+            }
         )
-        link = create_link(assignments, tainted=tainted, transiting_identifiers=transiting_identifiers)
+        link = create_link(
+            assignments, tainted={Identifier("5")}, transiting_identifiers={Identifier("2"), Identifier("3")}
+        )
         assert {entity.identifier for entity in link[Components.SOURCE] if entity.state is state} == set(expected)
-
-    @staticmethod
-    def test_received_entities_get_correct_state_assigned() -> None:
-        assignments = create_assignments(
-            {Components.SOURCE: {"1"}, Components.OUTBOUND: {"1"}, Components.LOCAL: {"1"}}
-        )
-        link = create_link(assignments, transiting_identifiers={Identifier("1")})
-        assert {entity.identifier for entity in link[Components.SOURCE] if entity.state is States.RECEIVED} == {
-            Identifier("1")
-        }
 
     @staticmethod
     @pytest.mark.parametrize(

--- a/tests/unit/entities/test_link.py
+++ b/tests/unit/entities/test_link.py
@@ -45,6 +45,16 @@ class TestCreateLink:
         assert {entity.identifier for entity in link[Components.SOURCE] if entity.state is state} == set(expected)
 
     @staticmethod
+    def test_received_entities_get_correct_state_assigned() -> None:
+        assignments = create_assignments(
+            {Components.SOURCE: {"1"}, Components.OUTBOUND: {"1"}, Components.LOCAL: {"1"}}
+        )
+        link = create_link(assignments, in_transit={Identifier("1")})
+        assert {entity.identifier for entity in link[Components.SOURCE] if entity.state is States.RECEIVED} == {
+            Identifier("1")
+        }
+
+    @staticmethod
     @pytest.mark.parametrize(
         "assignments,expectation",
         [

--- a/tests/unit/entities/test_link.py
+++ b/tests/unit/entities/test_link.py
@@ -34,6 +34,7 @@ class TestCreateLink:
             (States.RECEIVED, {Identifier("3")}),
             (States.PULLED, {Identifier("4")}),
             (States.TAINTED, {Identifier("5")}),
+            (States.DEPRECATED, {Identifier("6")}),
         ],
     )
     def test_entities_get_correct_state_assigned(
@@ -42,14 +43,14 @@ class TestCreateLink:
     ) -> None:
         assignments = create_assignments(
             {
-                Components.SOURCE: {"1", "2", "3", "4", "5"},
+                Components.SOURCE: {"1", "2", "3", "4", "5", "6"},
                 Components.OUTBOUND: {"2", "3", "4", "5"},
                 Components.LOCAL: {"3", "4", "5"},
             }
         )
         link = create_link(
             assignments,
-            tainted_identifiers={Identifier("5")},
+            tainted_identifiers={Identifier("5"), Identifier("6")},
             transiting_identifiers={Identifier("2"), Identifier("3")},
         )
         assert {entity.identifier for entity in link[Components.SOURCE] if entity.state is state} == set(expected)

--- a/tests/unit/entities/test_link.py
+++ b/tests/unit/entities/test_link.py
@@ -65,6 +65,23 @@ class TestCreateLink:
             ),
         ],
     )
+    def test_only_entities_present_in_all_components_can_be_received(
+        assignments: Mapping[Components, Iterable[Identifier]], expectation: ContextManager[None]
+    ) -> None:
+        with expectation:
+            create_link(assignments, in_transit={Identifier("1")})
+
+    @staticmethod
+    @pytest.mark.parametrize(
+        "assignments,expectation",
+        [
+            (create_assignments({Components.SOURCE: {"1"}}), pytest.raises(AssertionError)),
+            (
+                create_assignments({Components.SOURCE: {"1"}, Components.OUTBOUND: {"1"}, Components.LOCAL: {"1"}}),
+                does_not_raise(),
+            ),
+        ],
+    )
     def test_only_pulled_entities_can_be_tainted(
         assignments: Mapping[Components, Iterable[Identifier]], expectation: ContextManager[None]
     ) -> None:

--- a/tests/unit/entities/test_link.py
+++ b/tests/unit/entities/test_link.py
@@ -48,7 +48,9 @@ class TestCreateLink:
             }
         )
         link = create_link(
-            assignments, tainted={Identifier("5")}, transiting_identifiers={Identifier("2"), Identifier("3")}
+            assignments,
+            tainted_identifiers={Identifier("5")},
+            transiting_identifiers={Identifier("2"), Identifier("3")},
         )
         assert {entity.identifier for entity in link[Components.SOURCE] if entity.state is state} == set(expected)
 
@@ -84,7 +86,7 @@ class TestCreateLink:
         assignments: Mapping[Components, Iterable[Identifier]], expectation: ContextManager[None]
     ) -> None:
         with expectation:
-            create_link(assignments, tainted={Identifier("1")})
+            create_link(assignments, tainted_identifiers={Identifier("1")})
 
     @staticmethod
     @pytest.mark.parametrize(
@@ -107,7 +109,7 @@ class TestCreateLink:
         assignments: Mapping[Components, Iterable[Identifier]], expectation: ContextManager[None]
     ) -> None:
         with expectation:
-            create_link(assignments, tainted={Identifier("1")})
+            create_link(assignments, tainted_identifiers={Identifier("1")})
 
     @staticmethod
     @pytest.mark.parametrize(

--- a/tests/unit/entities/test_link.py
+++ b/tests/unit/entities/test_link.py
@@ -58,40 +58,6 @@ class TestCreateLink:
     @pytest.mark.parametrize(
         "assignments,expectation",
         [
-            (create_assignments({Components.SOURCE: {"1"}}), pytest.raises(AssertionError)),
-            (
-                create_assignments({Components.SOURCE: {"1"}, Components.OUTBOUND: {"1"}, Components.LOCAL: {"1"}}),
-                does_not_raise(),
-            ),
-        ],
-    )
-    def test_only_entities_present_in_all_components_can_be_received(
-        assignments: Mapping[Components, Iterable[Identifier]], expectation: ContextManager[None]
-    ) -> None:
-        with expectation:
-            create_link(assignments, transiting_identifiers={Identifier("1")})
-
-    @staticmethod
-    @pytest.mark.parametrize(
-        "assignments,expectation",
-        [
-            (create_assignments({Components.SOURCE: {"1"}}), pytest.raises(AssertionError)),
-            (
-                create_assignments({Components.SOURCE: {"1"}, Components.OUTBOUND: {"1"}, Components.LOCAL: {"1"}}),
-                does_not_raise(),
-            ),
-        ],
-    )
-    def test_only_pulled_entities_can_be_tainted(
-        assignments: Mapping[Components, Iterable[Identifier]], expectation: ContextManager[None]
-    ) -> None:
-        with expectation:
-            create_link(assignments, tainted_identifiers={Identifier("1")})
-
-    @staticmethod
-    @pytest.mark.parametrize(
-        "assignments,expectation",
-        [
             (create_assignments(), pytest.raises(AssertionError)),
             (
                 create_assignments({Components.SOURCE: {"1"}, Components.OUTBOUND: {"1"}, Components.LOCAL: {"1"}}),

--- a/tests/unit/entities/test_link.py
+++ b/tests/unit/entities/test_link.py
@@ -100,21 +100,24 @@ class TestCreateLink:
 
     @staticmethod
     @pytest.mark.parametrize(
-        "assignments,expectation",
+        "transiting_identifiers,assignments,expectation",
         [
+            (set(), create_assignments({Components.LOCAL: {"1"}}), pytest.raises(AssertionError)),
+            (set(), create_assignments(), does_not_raise()),
             (
-                create_assignments({Components.SOURCE: {"1"}, Components.OUTBOUND: {"1"}, Components.LOCAL: {"1"}}),
+                {Identifier("1")},
+                create_assignments({Components.SOURCE: {"1"}, Components.OUTBOUND: {"1"}}),
                 does_not_raise(),
             ),
-            (create_assignments({Components.SOURCE: {"1"}, Components.OUTBOUND: {"1"}}), pytest.raises(AssertionError)),
-            (create_assignments({Components.SOURCE: {"1"}, Components.LOCAL: {"1"}}), pytest.raises(AssertionError)),
         ],
     )
-    def test_local_identifiers_must_be_identical_to_outbound_identifiers(
-        assignments: Mapping[Components, Iterable[Identifier]], expectation: ContextManager[None]
+    def test_local_identifiers_can_not_be_superset_of_outbound_identifiers(
+        transiting_identifiers: Iterable[Identifier],
+        assignments: Mapping[Components, Iterable[Identifier]],
+        expectation: ContextManager[None],
     ) -> None:
         with expectation:
-            create_link(assignments)
+            create_link(assignments, transiting_identifiers=transiting_identifiers)
 
 
 class TestLink:

--- a/tests/unit/entities/test_link.py
+++ b/tests/unit/entities/test_link.py
@@ -31,6 +31,7 @@ class TestCreateLink:
         [
             (set(), States.IDLE, {Identifier("2")}),
             (set(), States.PULLED, {Identifier("1")}),
+            (set(), States.ACTIVATED, {Identifier("3")}),
             ({Identifier("1")}, States.TAINTED, {Identifier("1")}),
         ],
     )
@@ -38,7 +39,7 @@ class TestCreateLink:
         tainted: Iterable[Identifier], state: States, expected: Iterable[Identifier]
     ) -> None:
         assignments = create_assignments(
-            {Components.SOURCE: {"1", "2"}, Components.OUTBOUND: {"1"}, Components.LOCAL: {"1"}}
+            {Components.SOURCE: {"1", "2", "3"}, Components.OUTBOUND: {"1", "3"}, Components.LOCAL: {"1"}}
         )
         link = create_link(assignments, tainted=tainted)
         assert {entity.identifier for entity in link[Components.SOURCE] if entity.state is state} == set(expected)


### PR DESCRIPTION
This PR adds the following new entity states:
* Activated: The entity is in the process of being pulled/deleted to/from the local side. It is only present on the source side.
* Received: Like an activated entity but it is present on both sides.
* Deprecated: The entity was previously tainted by the source side and then deleted (i.e. deprecated) by the local side.
