### PR TITLE
Add ruff linter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        linter: ["black", "isort", "mypy", "flake8", "pylint"]
+        linter: ["black", "isort", "mypy", "flake8", "pylint", "ruff"]
     steps:
       - name: Check out code
         uses: actions/checkout@v3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,3 +37,9 @@ repos:
         language: system
         types: [python]
         pass_filenames: false
+      - id: ruff
+        name: ruff
+        entry: pdm run lint_ruff
+        language: system
+        types: [python]
+        pass_filenames: false

--- a/dj_link/frameworks/datajoint/link.py
+++ b/dj_link/frameworks/datajoint/link.py
@@ -70,7 +70,7 @@ class LocalTableCreator:  # pylint: disable=too-few-public-methods
     schema_class = Schema
     replace_stores: staticmethod[str] = staticmethod(replace_stores)  # noqa: F811
 
-    def __init__(
+    def __init__(  # noqa: PLR0913
         self,
         local_schema: Union[Schema, LazySchema],
         source_schema: Union[Schema, LazySchema],

--- a/dj_link/schemas.py
+++ b/dj_link/schemas.py
@@ -34,7 +34,7 @@ class LazySchema:  # pylint: disable=too-many-instance-attributes
     _schema_cls = Schema
     _conn_cls = Connection
 
-    def __init__(
+    def __init__(  # noqa: PLR0913
         self,
         schema_name: str,
         context: Optional[Dict] = None,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,6 +50,9 @@ services:
   pylint:
     build: .
     command: ["lint_pylint"]
+  ruff:
+    build: .
+    command: ["lint_ruff"]
 
 networks:
   test:

--- a/pdm.lock
+++ b/pdm.lock
@@ -589,6 +589,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ruff"
+version = "0.0.270"
+requires_python = ">=3.7"
+summary = "An extremely fast Python linter, written in Rust."
+
+[[package]]
 name = "six"
 version = "1.16.0"
 requires_python = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
@@ -683,8 +689,9 @@ requires_python = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 summary = "Module for decorators, wrappers and monkey patching."
 
 [metadata]
-lock_version = "4.1"
-content_hash = "sha256:30f30ebe400879fec9893c53024418e9caf5f5cd9e36646ef78eb91b9cbdcce2"
+lock_version = "4.2"
+groups = ["default", "dev", "profiling"]
+content_hash = "sha256:2ecf9775d4160800318bba9b12711dfa13bb891053905c912bc847fe837b9956"
 
 [metadata.files]
 "appnope 0.1.3" = [
@@ -1503,6 +1510,25 @@ content_hash = "sha256:30f30ebe400879fec9893c53024418e9caf5f5cd9e36646ef78eb91b9
 "requests 2.28.1" = [
     {url = "https://files.pythonhosted.org/packages/a5/61/a867851fd5ab77277495a8709ddda0861b28163c4613b011bc00228cc724/requests-2.28.1.tar.gz", hash = "sha256:7c5599b102feddaa661c826c56ab4fee28bfd17f5abca1ebbe3e7f19d7c97983"},
     {url = "https://files.pythonhosted.org/packages/ca/91/6d9b8ccacd0412c08820f72cebaa4f0c0441b5cda699c90f618b6f8a1b42/requests-2.28.1-py3-none-any.whl", hash = "sha256:8fefa2a1a1365bf5520aac41836fbee479da67864514bdb821f31ce07ce65349"},
+]
+"ruff 0.0.270" = [
+    {url = "https://files.pythonhosted.org/packages/02/d1/77f9425bea1e5a929ecbeb3fd9e2e0931e30751b4d75bbe8b46e14408ada/ruff-0.0.270-py3-none-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:643de865fd35cb76c4f0739aea5afe7b8e4d40d623df7e9e6ea99054e5cead0a"},
+    {url = "https://files.pythonhosted.org/packages/06/56/39079c40dc7e995f26f630d28dec11b1b63f498bfb56409adda27300bf2f/ruff-0.0.270-py3-none-win_amd64.whl", hash = "sha256:0012f9b7dc137ab7f1f0355e3c4ca49b562baf6c9fa1180948deeb6648c52957"},
+    {url = "https://files.pythonhosted.org/packages/36/21/aa8e1d22756e1d3bcdb43f4d25451f8978cacd9d6896e365bb7c1f9037fa/ruff-0.0.270-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:08188f8351f4c0b6216e8463df0a76eb57894ca59a3da65e4ed205db980fd3ae"},
+    {url = "https://files.pythonhosted.org/packages/36/ab/ff2870e22556c780d6b0b2934152e824ca0d3d40d9e3dedb44a158a979dc/ruff-0.0.270-py3-none-musllinux_1_2_i686.whl", hash = "sha256:0bbfbf6fd2436165566ca85f6e57be03ed2f0a994faf40180cfbb3604c9232ef"},
+    {url = "https://files.pythonhosted.org/packages/40/82/c393794c4cd462ffbd0afe45b8e77c174c7f3d5df4340ecead9a42d1fa53/ruff-0.0.270-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0827b074635d37984fc98d99316bfab5c8b1231bb83e60dacc83bd92883eedb4"},
+    {url = "https://files.pythonhosted.org/packages/57/2f/3f964a1d0208248f3c51441a9e59690c8ac6f33422a0f0918521743c9f16/ruff-0.0.270-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0d61ae4841313f6eeb8292dc349bef27b4ce426e62c36e80ceedc3824e408734"},
+    {url = "https://files.pythonhosted.org/packages/5a/22/e4e4d9219993e3b7f34ba16b9b14176d19bc77232daf70d176ee86687d51/ruff-0.0.270-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:739495d2dbde87cf4e3110c8d27bc20febf93112539a968a4e02c26f0deccd1d"},
+    {url = "https://files.pythonhosted.org/packages/7f/2c/3989a9296e058720b65106bcb4756781ddada2c258fb2f54be0e702602cf/ruff-0.0.270-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:eca02e709b3308eb7255b5f74e779be23b5980fca3862eae28bb23069cd61ae4"},
+    {url = "https://files.pythonhosted.org/packages/9a/fb/625f83b6e19ef8d78f68cc43afdcb26f0e59ed83c3c569f7cdfa09afd276/ruff-0.0.270-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:21f00e47ab2308617c44435c8dfd9e2e03897461c9e647ec942deb2a235b4cfd"},
+    {url = "https://files.pythonhosted.org/packages/a6/fc/fd90a58b09ec004f773617a92e0844e30830791e9c6e39582fae414966c2/ruff-0.0.270-py3-none-win_arm64.whl", hash = "sha256:9613456b0b375766244c25045e353bc8890c856431cd97893c97b10cc93bd28d"},
+    {url = "https://files.pythonhosted.org/packages/af/a0/2b773726f2b534acc32ea60b51a3e2f0b130b68a67a32baa099536c153a4/ruff-0.0.270-py3-none-win32.whl", hash = "sha256:b4c037fe2f75bcd9aed0c89c7c507cb7fa59abae2bd4c8b6fc331a28178655a4"},
+    {url = "https://files.pythonhosted.org/packages/b0/6f/d875381e8ca1070b6065aad1095b5b7dff0a2b2198962f72166efd6bbf24/ruff-0.0.270.tar.gz", hash = "sha256:95db07b7850b30ebf32b27fe98bc39e0ab99db3985edbbf0754d399eb2f0e690"},
+    {url = "https://files.pythonhosted.org/packages/b2/4d/c74c7223aa96e2168aa55042a9123a41daddb585e1d492b10de45bcf4db9/ruff-0.0.270-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:b775e2c5fc869359daf8c8b8aa0fd67240201ab2e8d536d14a0edf279af18786"},
+    {url = "https://files.pythonhosted.org/packages/c0/90/cdbb101b1864aba6a785ef5a91c426abd4d76a3863054496c7c32a20ace8/ruff-0.0.270-py3-none-macosx_10_7_x86_64.whl", hash = "sha256:f74c4d550f7b8e808455ac77bbce38daafc458434815ba0bc21ae4bdb276509b"},
+    {url = "https://files.pythonhosted.org/packages/cb/1e/c6aa0c7e443bae068fe151c592d07078dbb75efcc4c8d73fbf8a7f872e85/ruff-0.0.270-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0eb412f20e77529a01fb94d578b19dcb8331b56f93632aa0cce4a2ea27b7aeba"},
+    {url = "https://files.pythonhosted.org/packages/dc/59/4f1e078ddf622e42096a45e3e3e3dd524499557044847261e40817f56d2e/ruff-0.0.270-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:8af391ef81f7be960be10886a3c1aac0b298bde7cb9a86ec2b05faeb2081ce6b"},
+    {url = "https://files.pythonhosted.org/packages/f0/48/a56cdeec0277aff92d68c39c282c9f7c01f38db37c5832605ee8c1ed8097/ruff-0.0.270-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3ed3b198768d2b3a2300fb18f730cd39948a5cc36ba29ae9d4639a11040880be"},
 ]
 "six 1.16.0" = [
     {url = "https://files.pythonhosted.org/packages/71/39/171f1c67cd00715f190ba0b100d606d440a28c93c7714febeca8b79af85e/six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ lint_isort = "isort --check-only --diff ."
 lint_mypy = "mypy"
 lint_flake8 = "flake8 ."
 lint_pylint = "pylint dj_link"
+lint_ruff = "ruff check ."
 tests = "pytest -m 'not slow'"
 functional_tests = "docker compose run functional_tests"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,9 +36,7 @@ dev = [
     "isort~=5.7",
     "mypy~=0.812",
     "flake8-docstrings~=1.6",
-    "black>=22.10.0",
-    "minio>=7.1.12",
-    "neovim>=0.3.1",
+    "black>=22.10.0", "minio>=7.1.12", "neovim>=0.3.1",
     "pdbpp>=0.10.3",
     "ruff>=0.0.270",
 ]
@@ -148,3 +146,14 @@ testpaths = [
 markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')"
 ]
+
+[tool.ruff]
+line-length = 120
+select = ["E", "F", "I", "D", "PL"]
+include = ["dj_link/*.py", "tests/*.py"]
+
+[tool.ruff.per-file-ignores]
+"tests/*.py" = ["D", "PL"]
+
+[tool.ruff.pydocstyle]
+convention = "pep257"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dev = [
     "minio>=7.1.12",
     "neovim>=0.3.1",
     "pdbpp>=0.10.3",
+    "ruff>=0.0.270",
 ]
 profiling = [
     "gprof2dot~=2021.2",


### PR DESCRIPTION
Ruff is a fast linter that can also fix many problems automatically. Therefore it might be a good replacement for flake8, pylint and isort.
