### PR TITLE
Remove outbound-related commands

### DIFF
--- a/dj_link/entities/state.py
+++ b/dj_link/entities/state.py
@@ -175,7 +175,6 @@ class Transition:
 class Commands(Enum):
     """Names for all the commands necessary to transition entities between states."""
 
-    REMOVE_FROM_OUTBOUND = auto()
     ADD_TO_LOCAL = auto()
     REMOVE_FROM_LOCAL = auto()
     START_PULL_PROCESS = auto()
@@ -189,8 +188,8 @@ class Commands(Enum):
 TRANSITION_MAP: dict[Transition, set[Commands]] = {
     Transition(Idle, Activated): {Commands.START_PULL_PROCESS},
     Transition(Activated, Received): {Commands.ADD_TO_LOCAL},
-    Transition(Activated, Idle): {Commands.REMOVE_FROM_OUTBOUND, Commands.FINISH_DELETE_PROCESS},
-    Transition(Activated, Deprecated): {Commands.REMOVE_FROM_OUTBOUND, Commands.FINISH_DELETE_PROCESS},
+    Transition(Activated, Idle): {Commands.FINISH_DELETE_PROCESS},
+    Transition(Activated, Deprecated): {Commands.FINISH_DELETE_PROCESS},
     Transition(Received, Pulled): {Commands.FINISH_PULL_PROCESS},
     Transition(Received, Activated): {Commands.REMOVE_FROM_LOCAL},
     Transition(Pulled, Received): {Commands.START_DELETE_PROCESS},

--- a/dj_link/entities/state.py
+++ b/dj_link/entities/state.py
@@ -175,7 +175,6 @@ class Transition:
 class Commands(Enum):
     """Names for all the commands necessary to transition entities between states."""
 
-    ADD_TO_OUTBOUND = auto()
     REMOVE_FROM_OUTBOUND = auto()
     ADD_TO_LOCAL = auto()
     REMOVE_FROM_LOCAL = auto()
@@ -188,7 +187,7 @@ class Commands(Enum):
 
 
 TRANSITION_MAP: dict[Transition, set[Commands]] = {
-    Transition(Idle, Activated): {Commands.ADD_TO_OUTBOUND, Commands.START_PULL_PROCESS},
+    Transition(Idle, Activated): {Commands.START_PULL_PROCESS},
     Transition(Activated, Received): {Commands.ADD_TO_LOCAL},
     Transition(Activated, Idle): {Commands.REMOVE_FROM_OUTBOUND, Commands.FINISH_DELETE_PROCESS},
     Transition(Activated, Deprecated): {Commands.REMOVE_FROM_OUTBOUND, Commands.FINISH_DELETE_PROCESS},

--- a/tests/unit/entities/test_state.py
+++ b/tests/unit/entities/test_state.py
@@ -44,7 +44,7 @@ def test_pulling_idle_entity_returns_correct_commands() -> None:
     assert entity.pull() == Update(
         Identifier("1"),
         Transition(states.Idle, states.Activated),
-        commands=frozenset({Commands.ADD_TO_OUTBOUND, Commands.START_PULL_PROCESS}),
+        commands=frozenset({Commands.START_PULL_PROCESS}),
     )
 
 

--- a/tests/unit/entities/test_state.py
+++ b/tests/unit/entities/test_state.py
@@ -52,13 +52,8 @@ def test_pulling_idle_entity_returns_correct_commands() -> None:
     "process,tainted_identifiers,new_state,commands",
     [
         (Processes.PULL, set(), states.Received, {Commands.ADD_TO_LOCAL}),
-        (Processes.DELETE, set(), states.Idle, {Commands.REMOVE_FROM_OUTBOUND, Commands.FINISH_DELETE_PROCESS}),
-        (
-            Processes.DELETE,
-            {Identifier("1")},
-            states.Deprecated,
-            {Commands.REMOVE_FROM_OUTBOUND, Commands.FINISH_DELETE_PROCESS},
-        ),
+        (Processes.DELETE, set(), states.Idle, {Commands.FINISH_DELETE_PROCESS}),
+        (Processes.DELETE, {Identifier("1")}, states.Deprecated, {Commands.FINISH_DELETE_PROCESS}),
     ],
 )
 def test_processing_activated_entity_returns_correct_commands(


### PR DESCRIPTION
There is no justification for having the ADD_TO_OUTBOUND and REMOVE_FROM_OUTBOUND commands because they are always used in conjunction with the START_PULL_PROCESS and FINISH_DELETE_PROCESS commands, respectively. Therefore they are superfluous.
