### PR TITLE
Enable ruff rules regarding pytest style

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,7 +141,7 @@ markers = [
 
 [tool.ruff]
 line-length = 120
-select = ["E", "F", "I", "D", "PL"]
+select = ["E", "F", "I", "D", "PL", "PT"]
 include = ["dj_link/*.py", "tests/*.py"]
 
 [tool.ruff.per-file-ignores]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,7 +18,7 @@ class IdentifierCreator(Protocol):
         ...
 
 
-@pytest.fixture
+@pytest.fixture()
 def create_identifiers() -> IdentifierCreator:
     def _create_identifiers(spec: Union[int, Iterable[int]]) -> list[str]:
         if isinstance(spec, int):
@@ -145,7 +145,7 @@ class FakeGatewayLink(GatewayLink):
         destination.insert(entity)
 
 
-@pytest.fixture
+@pytest.fixture()
 def fake_gateway_link() -> FakeGatewayLink:
     return FakeGatewayLink()
 
@@ -155,7 +155,7 @@ class FakeGatewayLinkCreator(Protocol):
         ...
 
 
-@pytest.fixture
+@pytest.fixture()
 def create_fake_gateway_link() -> FakeGatewayLinkCreator:
     def _create_fake_gateway_link(identifiers: GatewayLinkIdentifiers) -> FakeGatewayLink:
         return FakeGatewayLink.from_identifiers(identifiers)

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -363,12 +363,12 @@ def get_minio_client():
     return _get_minio_client
 
 
-@pytest.fixture
+@pytest.fixture()
 def src_store_config(temp_stores):
     return temp_stores["source"]
 
 
-@pytest.fixture
+@pytest.fixture()
 def get_store_spec(create_random_string):
     def _get_store_spec(minio_spec, protocol="s3", port=9000):
         return StoreConfig(
@@ -384,12 +384,12 @@ def get_store_spec(create_random_string):
     return _get_store_spec
 
 
-@pytest.fixture
+@pytest.fixture()
 def local_store_config(temp_stores):
     return temp_stores["local"]
 
 
-@pytest.fixture
+@pytest.fixture()
 def dj_connection():
     @contextmanager
     def _dj_connection(db_spec, user_spec):
@@ -402,7 +402,7 @@ def dj_connection():
     return _dj_connection
 
 
-@pytest.fixture
+@pytest.fixture()
 def connection_config():
     @contextmanager
     def _connection_config(db_spec, user):
@@ -424,7 +424,7 @@ def connection_config():
     return _connection_config
 
 
-@pytest.fixture
+@pytest.fixture()
 def temp_dj_store_config():
     @contextmanager
     def _temp_dj_store_config(stores):
@@ -434,7 +434,7 @@ def temp_dj_store_config():
     return _temp_dj_store_config
 
 
-@pytest.fixture
+@pytest.fixture()
 def temp_store(get_minio_client, get_store_spec):
     @contextmanager
     def _temp_store(minio_spec):
@@ -470,13 +470,13 @@ def temp_store(get_minio_client, get_store_spec):
     return _temp_store
 
 
-@pytest.fixture
+@pytest.fixture()
 def temp_stores(temp_store, src_minio_spec, local_minio_spec):
     with temp_store(src_minio_spec) as src_store_spec, temp_store(local_minio_spec) as local_store_spec:
         yield {"source": src_store_spec, "local": local_store_spec}
 
 
-@pytest.fixture
+@pytest.fixture()
 def test_session(src_db_spec, local_db_spec, dj_connection, outbound_schema_name):
     with dj_connection(src_db_spec, src_db_spec.config.users["end_user"]) as src_conn:
         with dj_connection(local_db_spec, local_db_spec.config.users["end_user"]) as local_conn:
@@ -491,22 +491,22 @@ def test_session(src_db_spec, local_db_spec, dj_connection, outbound_schema_name
         src_schema.drop(force=True)
 
 
-@pytest.fixture
+@pytest.fixture()
 def src_schema(test_session):
     return test_session["src"]
 
 
-@pytest.fixture
+@pytest.fixture()
 def local_schema(test_session):
     return test_session["local"]
 
 
-@pytest.fixture
+@pytest.fixture()
 def src_table_name():
     return "Table"
 
 
-@pytest.fixture
+@pytest.fixture()
 def src_table_definition():
     return """
     prim_attr: int
@@ -515,7 +515,7 @@ def src_table_definition():
     """
 
 
-@pytest.fixture
+@pytest.fixture()
 def src_table_cls(src_table_name, src_table_definition):
     class Table(dj.Manual):
         definition = src_table_definition
@@ -524,17 +524,17 @@ def src_table_cls(src_table_name, src_table_definition):
     return Table
 
 
-@pytest.fixture
+@pytest.fixture()
 def n_entities():
     return int(os.environ.get("N_ENTITIES", 10))
 
 
-@pytest.fixture
+@pytest.fixture()
 def src_data(n_entities):
     return [dict(prim_attr=i, sec_attr=-i) for i in range(n_entities)]
 
 
-@pytest.fixture
+@pytest.fixture()
 def src_table_with_data(
     src_schema, src_table_cls, src_data, src_db_spec, connection_config, src_store_config, temp_dj_store_config
 ):
@@ -544,20 +544,20 @@ def src_table_with_data(
     return src_table
 
 
-@pytest.fixture
+@pytest.fixture()
 def remote_schema(src_db_spec):
     os.environ["LINK_USER"] = src_db_spec.config.users["dj_user"].name
     os.environ["LINK_PASS"] = src_db_spec.config.users["dj_user"].password
     return LazySchema(src_db_spec.config.schema_name, host=src_db_spec.container.name)
 
 
-@pytest.fixture
+@pytest.fixture()
 def stores(request, src_store_config, local_store_config):
     if getattr(request.module, "USES_EXTERNAL"):
         return {local_store_config.name: src_store_config.name}
 
 
-@pytest.fixture
+@pytest.fixture()
 def local_table_cls(
     local_schema,
     remote_schema,
@@ -579,7 +579,7 @@ def local_table_cls(
     return Table
 
 
-@pytest.fixture
+@pytest.fixture()
 def local_table_cls_with_pulled_data(
     src_table_with_data,
     local_table_cls,
@@ -596,7 +596,7 @@ def local_table_cls_with_pulled_data(
     return local_table_cls
 
 
-@pytest.fixture
+@pytest.fixture()
 def temp_env_vars():
     @contextmanager
     def _temp_env_vars(**vars):
@@ -614,7 +614,7 @@ def temp_env_vars():
     return _temp_env_vars
 
 
-@pytest.fixture
+@pytest.fixture()
 def configured_environment(temp_env_vars):
     @contextmanager
     def _configured_environment(user_spec, schema_name):
@@ -624,7 +624,7 @@ def configured_environment(temp_env_vars):
     return _configured_environment
 
 
-@pytest.fixture
+@pytest.fixture()
 def create_table(dj_connection, create_random_string):
     def _create_table(db_spec, user_spec, schema_name, definition, data=None):
         def create_random_table_name():
@@ -643,7 +643,7 @@ def create_table(dj_connection, create_random_string):
     return _create_table
 
 
-@pytest.fixture
+@pytest.fixture()
 def prepare_multiple_links(create_random_string, create_user, databases):
     def _prepare_multiple_links(n_local_schemas):
         def create_schema_names():
@@ -673,7 +673,7 @@ def prepare_multiple_links(create_random_string, create_user, databases):
     return _prepare_multiple_links
 
 
-@pytest.fixture
+@pytest.fixture()
 def prepare_link(prepare_multiple_links):
     def _prepare_link():
         schema_names, user_specs = prepare_multiple_links(1)

--- a/tests/functional/test_delete/test_delete.py
+++ b/tests/functional/test_delete/test_delete.py
@@ -7,7 +7,7 @@ import pytest
 USES_EXTERNAL = False
 
 
-@pytest.fixture
+@pytest.fixture()
 def deletion_requested_entities_primary_keys(n_entities, src_data):
     proportion_deletion_requested = float(os.environ.get("PROPORTION_DELETION_REQUESTED", 0.2))
     n_deletion_requested = round(n_entities * proportion_deletion_requested)
@@ -16,17 +16,17 @@ def deletion_requested_entities_primary_keys(n_entities, src_data):
     return sorted([dict(prim_attr=e["prim_attr"]) for e in deletion_requested_entities], key=lambda e: e["prim_attr"])
 
 
-@pytest.fixture
+@pytest.fixture()
 def outbound_deletion_requested_flags(deletion_requested_entities_primary_keys):
     return [e for e in deletion_requested_entities_primary_keys]
 
 
-@pytest.fixture
+@pytest.fixture()
 def expected_local_deletion_requested_flags(deletion_requested_entities_primary_keys):
     return [e for e in deletion_requested_entities_primary_keys]
 
 
-@pytest.fixture
+@pytest.fixture()
 def outbound_table_cls(
     src_db_spec, local_db_spec, outbound_schema_name, src_table_name, local_table_cls, dj_connection
 ):
@@ -35,13 +35,13 @@ def outbound_table_cls(
         return getattr(module, src_table_name + "Outbound")
 
 
-@pytest.fixture
+@pytest.fixture()
 def insert_flags_and_refresh(local_table_cls_with_pulled_data, outbound_deletion_requested_flags, outbound_table_cls):
     outbound_table_cls().DeletionRequested().insert(outbound_deletion_requested_flags)
     local_table_cls_with_pulled_data().refresh()
 
 
-@pytest.fixture
+@pytest.fixture()
 def insert_flags_refresh_and_delete_deletion_requested_entities(
     insert_flags_and_refresh, local_table_cls_with_pulled_data
 ):

--- a/tests/functional/test_delete/test_delete.py
+++ b/tests/functional/test_delete/test_delete.py
@@ -36,20 +36,20 @@ def outbound_table_cls(
 
 
 @pytest.fixture()
-def insert_flags_and_refresh(local_table_cls_with_pulled_data, outbound_deletion_requested_flags, outbound_table_cls):
+def _insert_flags_and_refresh(local_table_cls_with_pulled_data, outbound_deletion_requested_flags, outbound_table_cls):
     outbound_table_cls().DeletionRequested().insert(outbound_deletion_requested_flags)
     local_table_cls_with_pulled_data().refresh()
 
 
 @pytest.fixture()
-def insert_flags_refresh_and_delete_deletion_requested_entities(
-    insert_flags_and_refresh, local_table_cls_with_pulled_data
+def _insert_flags_refresh_and_delete_deletion_requested_entities(
+    _insert_flags_and_refresh, local_table_cls_with_pulled_data
 ):
     flags = local_table_cls_with_pulled_data().DeletionRequested.fetch(as_dict=True)
     (local_table_cls_with_pulled_data() & flags).delete()
 
 
-@pytest.mark.usefixtures("insert_flags_and_refresh")
+@pytest.mark.usefixtures("_insert_flags_and_refresh")
 def test_if_deletion_requested_entities_are_present_in_deletion_requested_part_table_on_local_side(
     local_table_cls_with_pulled_data, expected_local_deletion_requested_flags
 ):
@@ -57,7 +57,7 @@ def test_if_deletion_requested_entities_are_present_in_deletion_requested_part_t
     assert actual_local_deletion_requested_flags == expected_local_deletion_requested_flags
 
 
-@pytest.mark.usefixtures("insert_flags_refresh_and_delete_deletion_requested_entities")
+@pytest.mark.usefixtures("_insert_flags_refresh_and_delete_deletion_requested_entities")
 def test_if_locally_deleted_deletion_requested_entities_are_present_in_deletion_approved_part_table_in_outbound_table(
     outbound_table_cls, outbound_deletion_requested_flags
 ):

--- a/tests/functional/test_pulling/conftest.py
+++ b/tests/functional/test_pulling/conftest.py
@@ -4,18 +4,18 @@ from tempfile import TemporaryDirectory
 import pytest
 
 
-@pytest.fixture
+@pytest.fixture()
 def src_dir():
     with TemporaryDirectory(prefix="link_test_src_") as temp_dir:
         yield temp_dir
 
 
-@pytest.fixture
+@pytest.fixture()
 def file_size():
     return int(os.environ.get("FILE_SIZE", 1024))
 
 
-@pytest.fixture
+@pytest.fixture()
 def file_paths(n_entities, file_size, src_dir):
     file_paths = []
     for i in range(n_entities):
@@ -26,17 +26,17 @@ def file_paths(n_entities, file_size, src_dir):
     return file_paths
 
 
-@pytest.fixture
+@pytest.fixture()
 def local_dir():
     with TemporaryDirectory(prefix="link_test_local_") as temp_dir:
         yield temp_dir
 
 
-@pytest.fixture
+@pytest.fixture()
 def pulled_data(local_table_cls_with_pulled_data):
     return local_table_cls_with_pulled_data().fetch(as_dict=True)
 
 
-@pytest.fixture
+@pytest.fixture()
 def expected_data(src_data):
     return src_data

--- a/tests/functional/test_pulling/test_pulling.py
+++ b/tests/functional/test_pulling/test_pulling.py
@@ -88,4 +88,5 @@ def test_pulling_with_external(
             local_table_cls = Link(local_schema, source_schema)(type(source_table_name, (dj.Manual,), {}))
             local_table_cls().pull()
             actual = local_table_cls().fetch(as_dict=True, download_path=tmpdir)
-            assert len(actual) == len(expected) and all(entry in expected for entry in actual)
+            assert len(actual) == len(expected)
+            assert all(entry in expected for entry in actual)

--- a/tests/functional/test_pulling/test_pulling_with_part/conftest.py
+++ b/tests/functional/test_pulling/test_pulling_with_part/conftest.py
@@ -2,7 +2,7 @@ import datajoint as dj
 import pytest
 
 
-@pytest.fixture
+@pytest.fixture()
 def src_part_definition():
     return """
     -> master
@@ -11,7 +11,7 @@ def src_part_definition():
     """
 
 
-@pytest.fixture
+@pytest.fixture()
 def src_part_cls(src_part_definition):
     class Part(dj.Part):
         definition = src_part_definition
@@ -19,28 +19,28 @@ def src_part_cls(src_part_definition):
     return Part
 
 
-@pytest.fixture
+@pytest.fixture()
 def src_table_cls(src_table_cls, src_part_cls):
     src_table_cls.Part = src_part_cls
     return src_table_cls
 
 
-@pytest.fixture
+@pytest.fixture()
 def src_part_data(src_data):
     return [dict(prim_attr=e["prim_attr"], sec_attr=e["sec_attr"] * 2) for e in src_data]
 
 
-@pytest.fixture
+@pytest.fixture()
 def src_table_with_data(src_table_with_data, src_part_data):
     src_table_with_data.Part().insert(src_part_data)
     return src_table_with_data
 
 
-@pytest.fixture
+@pytest.fixture()
 def pulled_data(pulled_data):
     return dict(master=pulled_data)
 
 
-@pytest.fixture
+@pytest.fixture()
 def expected_data(expected_data, src_part_data):
     return dict(master=expected_data, part=src_part_data)

--- a/tests/functional/test_pulling/test_pulling_with_part/test_pulling_with_part.py
+++ b/tests/functional/test_pulling/test_pulling_with_part/test_pulling_with_part.py
@@ -3,7 +3,7 @@ import pytest
 USES_EXTERNAL = False
 
 
-@pytest.fixture
+@pytest.fixture()
 def pulled_data(pulled_data, local_table_cls):
     pulled_data["part"] = local_table_cls.Part().fetch(as_dict=True)
     return pulled_data

--- a/tests/functional/test_pulling/test_pulling_with_part/test_pulling_with_part_and_external.py
+++ b/tests/functional/test_pulling/test_pulling_with_part/test_pulling_with_part_and_external.py
@@ -5,24 +5,24 @@ import pytest
 USES_EXTERNAL = True
 
 
-@pytest.fixture
+@pytest.fixture()
 def src_part_definition(src_part_definition, src_store_config):
     src_part_definition += "ext_attr: attach@" + src_store_config.name
     return src_part_definition
 
 
-@pytest.fixture
+@pytest.fixture()
 def src_part_data(src_part_data, file_paths):
     return [dict(e, ext_attr=f) for e, f in zip(src_part_data, file_paths)]
 
 
-@pytest.fixture
+@pytest.fixture()
 def pulled_data(pulled_data, local_table_cls, local_dir):
     pulled_data["part"] = local_table_cls.Part().fetch(as_dict=True, download_path=local_dir)
     return pulled_data
 
 
-@pytest.fixture
+@pytest.fixture()
 def expected_data(expected_data, local_dir):
     for entity in expected_data["part"]:
         entity["ext_attr"] = os.path.join(local_dir, os.path.basename(entity["ext_attr"]))

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -7,7 +7,7 @@ from dj_link.use_cases import REQUEST_MODELS, USE_CASES, initialize_use_cases
 from dj_link.use_cases.gateway import GatewayLink
 
 
-@pytest.fixture
+@pytest.fixture()
 def config():
     return {
         "identifiers": {"source": 0, "outbound": 0, "local": 0},
@@ -18,7 +18,7 @@ def config():
     }
 
 
-@pytest.fixture
+@pytest.fixture()
 def processed_config(config, create_identifiers):
     processed = deepcopy(config)
     for repo_name, repo_identifier_spec in processed["identifiers"].items():
@@ -28,7 +28,7 @@ def processed_config(config, create_identifiers):
     return processed
 
 
-@pytest.fixture
+@pytest.fixture()
 def gateway_link_spy(processed_config):
     spy = create_autospec(GatewayLink, instance=True)
     for repo_name, identifiers in processed_config["identifiers"].items():
@@ -50,21 +50,21 @@ def gateway_link_spy(processed_config):
     return spy
 
 
-@pytest.fixture
+@pytest.fixture()
 def output_port_spies():
     return {n: MagicMock(name=n + "_output_port_spy") for n in USE_CASES}
 
 
-@pytest.fixture
+@pytest.fixture()
 def initialized_use_cases(gateway_link_spy, output_port_spies):
     return initialize_use_cases(gateway_link_spy, output_port_spies)
 
 
-@pytest.fixture
+@pytest.fixture()
 def use_case(request, initialized_use_cases):
     return initialized_use_cases[request.module.USE_CASE]
 
 
-@pytest.fixture
+@pytest.fixture()
 def request_model(request):
     return REQUEST_MODELS[request.module.USE_CASE]

--- a/tests/integration/test_integration_delete_use_case.py
+++ b/tests/integration/test_integration_delete_use_case.py
@@ -5,7 +5,7 @@ import pytest
 USE_CASE = "delete"
 
 
-@pytest.fixture
+@pytest.fixture()
 def config():
     return {
         "identifiers": {"source": 10, "outbound": 5, "local": 5},
@@ -16,7 +16,7 @@ def config():
     }
 
 
-@pytest.fixture
+@pytest.fixture()
 def to_be_deleted_identifiers(create_identifiers):
     return create_identifiers(3)
 

--- a/tests/integration/test_integration_delete_use_case.py
+++ b/tests/integration/test_integration_delete_use_case.py
@@ -22,7 +22,7 @@ def to_be_deleted_identifiers(create_identifiers):
 
 
 @pytest.fixture(autouse=True)
-def execute_delete(use_case, request_model, to_be_deleted_identifiers):
+def _execute_delete(use_case, request_model, to_be_deleted_identifiers):
     use_case(request_model(to_be_deleted_identifiers))
 
 

--- a/tests/integration/test_integration_refresh_use_case.py
+++ b/tests/integration/test_integration_refresh_use_case.py
@@ -5,7 +5,7 @@ import pytest
 USE_CASE = "refresh"
 
 
-@pytest.fixture
+@pytest.fixture()
 def config():
     return {
         "identifiers": {"source": 10, "outbound": 5, "local": 5},

--- a/tests/integration/test_pull.py
+++ b/tests/integration/test_pull.py
@@ -22,7 +22,7 @@ class FakeOutputPort(Generic[ResponseModel]):
         self.response = response
 
 
-@pytest.fixture
+@pytest.fixture()
 def fake_output_port() -> FakeOutputPort[PullResponseModel]:
     return FakeOutputPort()
 

--- a/tests/unit/adapters/datajoint/test_adapters_init.py
+++ b/tests/unit/adapters/datajoint/test_adapters_init.py
@@ -16,7 +16,7 @@ def repo_type(request):
 
 
 class TestDataJointGatewayLink:
-    @pytest.fixture
+    @pytest.fixture()
     def gateway_stubs(self):
         gateway_stubs = {}
         for repo_type in REPOSITORY_NAMES:
@@ -24,7 +24,7 @@ class TestDataJointGatewayLink:
             gateway_stubs[repo_type] = gateway_stub
         return gateway_stubs
 
-    @pytest.fixture
+    @pytest.fixture()
     def gateway_link(self, gateway_stubs):
         return DataJointGatewayLink(**{kind: gateway for kind, gateway in gateway_stubs.items()})
 
@@ -36,23 +36,23 @@ class TestDataJointGatewayLink:
 
 
 class TestInitializeAdapters:
-    @pytest.fixture
+    @pytest.fixture()
     def table_facade_link_stub(self):
         return MagicMock(name="table_facade_link_stub", spec=AbstractTableFacadeLink)
 
-    @pytest.fixture
+    @pytest.fixture()
     def initialize_adapters_return_value(self, table_facade_link_stub):
         return initialize_adapters(table_facade_link_stub)
 
-    @pytest.fixture
+    @pytest.fixture()
     def gateway_link(self, initialize_adapters_return_value):
         return initialize_adapters_return_value[0]
 
-    @pytest.fixture
+    @pytest.fixture()
     def view_model(self, initialize_adapters_return_value):
         return initialize_adapters_return_value[1]
 
-    @pytest.fixture
+    @pytest.fixture()
     def presenter(self, initialize_adapters_return_value):
         return initialize_adapters_return_value[2]
 

--- a/tests/unit/adapters/datajoint/test_adapters_init.py
+++ b/tests/unit/adapters/datajoint/test_adapters_init.py
@@ -71,10 +71,8 @@ class TestInitializeAdapters:
         assert isinstance(getattr(gateway_link, repo_type).translator, IdentificationTranslator)
 
     def test_if_the_same_translator_is_used_in_all_gateways(self, gateway_link):
-        assert (
-            gateway_link.source.translator is gateway_link.outbound.translator
-            and gateway_link.outbound.translator is gateway_link.local.translator
-        )
+        assert gateway_link.source.translator is gateway_link.outbound.translator
+        assert gateway_link.outbound.translator is gateway_link.local.translator
 
     def test_if_view_model_is_returned(self, view_model):
         assert isinstance(view_model, ViewModel)

--- a/tests/unit/adapters/datajoint/test_presenter.py
+++ b/tests/unit/adapters/datajoint/test_presenter.py
@@ -23,14 +23,14 @@ class TestViewModel:
         assert str(exc_info.value) == attr_name.title() + " attribute not set"
 
     @pytest.fixture()
-    def update_model(self, model):
+    def _update_model(self, model):
         model.update("Hello World!", {"apples": 10})
 
-    @pytest.mark.usefixtures("update_model")
+    @pytest.mark.usefixtures("_update_model")
     def test_if_message_property_returns_message_if_model_has_been_updated(self, model):
         assert model.message == "Hello World!"
 
-    @pytest.mark.usefixtures("update_model")
+    @pytest.mark.usefixtures("_update_model")
     def test_if_fields_property_returns_fields_if_model_has_been_updated(self, model):
         assert model.fields == {"apples": 10}
 

--- a/tests/unit/adapters/datajoint/test_presenter.py
+++ b/tests/unit/adapters/datajoint/test_presenter.py
@@ -12,7 +12,7 @@ class TestViewModel:
     def test_if_dataclass(self):
         assert is_dataclass(ViewModel)
 
-    @pytest.fixture
+    @pytest.fixture()
     def model(self):
         return ViewModel()
 
@@ -22,7 +22,7 @@ class TestViewModel:
             getattr(model, attr_name)
         assert str(exc_info.value) == attr_name.title() + " attribute not set"
 
-    @pytest.fixture
+    @pytest.fixture()
     def update_model(self, model):
         model.update("Hello World!", {"apples": 10})
 
@@ -39,12 +39,12 @@ def test_if_subclass_of_base():
     assert issubclass(Presenter, Base)
 
 
-@pytest.fixture
+@pytest.fixture()
 def view_model_spy():
     return create_autospec(ViewModel, instance=True)
 
 
-@pytest.fixture
+@pytest.fixture()
 def presenter(view_model_spy):
     return Presenter(view_model_spy)
 
@@ -55,7 +55,7 @@ class TestInit:
 
 
 class TestPull:
-    @pytest.fixture
+    @pytest.fixture()
     def response_model_stub(self):
         stub = create_autospec(RESPONSE_MODELS["pull"], instance=True)
         stub.n_requested = 10
@@ -72,7 +72,7 @@ class TestPull:
 
 
 class TestDelete:
-    @pytest.fixture
+    @pytest.fixture()
     def response_model_stub(self):
         stub = create_autospec(RESPONSE_MODELS["delete"], instance=True)
         stub.n_requested = 10
@@ -95,7 +95,7 @@ class TestDelete:
 
 
 class TestRefresh:
-    @pytest.fixture
+    @pytest.fixture()
     def response_model_stub(self):
         stub = create_autospec(RESPONSE_MODELS["refresh"], instance=True)
         stub.n_refreshed = 10

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,11 +1,11 @@
 import pytest
 
 
-@pytest.fixture
+@pytest.fixture()
 def n_identifiers():
     return 10
 
 
-@pytest.fixture
+@pytest.fixture()
 def identifiers(n_identifiers):
     return ["ID" + str(i) for i in range(n_identifiers)]

--- a/tests/unit/entities/conftest.py
+++ b/tests/unit/entities/conftest.py
@@ -7,22 +7,22 @@ from dj_link.entities.abstract_gateway import AbstractGateway
 from dj_link.entities.repository import Entity
 
 
-@pytest.fixture
+@pytest.fixture()
 def identifiers():
     return ["identifier" + str(i) for i in range(10)]
 
 
-@pytest.fixture
+@pytest.fixture()
 def identifier(identifiers):
     return identifiers[0]
 
 
-@pytest.fixture
+@pytest.fixture()
 def flags(identifiers):
     return {identifier: dict(flag1=True, flag2=False) for identifier in identifiers}
 
 
-@pytest.fixture
+@pytest.fixture()
 def entities(flags):
     return {
         identifier: create_autospec(Entity, instance=True, identifier=identifier, flags=entity_flags)
@@ -30,17 +30,17 @@ def entities(flags):
     }
 
 
-@pytest.fixture
+@pytest.fixture()
 def entity(identifier, entities):
     return entities[identifier]
 
 
-@pytest.fixture
+@pytest.fixture()
 def entity_data():
     return "data"
 
 
-@pytest.fixture
+@pytest.fixture()
 def wrap_spy_around_method():
     def _wrap_spy_around_method(instance, method):
         setattr(
@@ -52,7 +52,7 @@ def wrap_spy_around_method():
     return _wrap_spy_around_method
 
 
-@pytest.fixture
+@pytest.fixture()
 def gateway_spy_cls():
     class GatewaySpy(AbstractGateway):
 
@@ -99,7 +99,7 @@ def gateway_spy_cls():
     return GatewaySpy
 
 
-@pytest.fixture
+@pytest.fixture()
 def gateway_spy(gateway_spy_cls, identifiers, flags, entity_data, wrap_spy_around_method):
     gateway_spy = gateway_spy_cls(identifiers, flags, entity_data)
     for method in [

--- a/tests/unit/entities/test_contents.py
+++ b/tests/unit/entities/test_contents.py
@@ -7,12 +7,12 @@ from dj_link.entities.contents import Contents
 from dj_link.entities.repository import TransferEntity
 
 
-@pytest.fixture
+@pytest.fixture()
 def entity_factory_spy(entity):
     return MagicMock(name="entity_factory_spy", return_value=entity)
 
 
-@pytest.fixture
+@pytest.fixture()
 def contents(entities, gateway_spy, entity_factory_spy):
     return Contents(gateway_spy, entity_factory_spy)
 
@@ -30,7 +30,7 @@ class TestInit:
 
 
 class TestGetItem:
-    @pytest.fixture
+    @pytest.fixture()
     def fetched_entity(self, identifier, contents):
         return contents[identifier]
 

--- a/tests/unit/entities/test_flag_manager.py
+++ b/tests/unit/entities/test_flag_manager.py
@@ -7,11 +7,11 @@ from dj_link.entities import flag_manager
 
 
 class TestFlagManager:
-    @pytest.fixture
+    @pytest.fixture()
     def entity_flags(self, entity):
         return entity.flags
 
-    @pytest.fixture
+    @pytest.fixture()
     def manager(self, entity, gateway_spy):
         return flag_manager.FlagManager(entity, gateway_spy)
 
@@ -56,11 +56,11 @@ class TestFlagManager:
 
 
 class TestFlagManagerFactory:
-    @pytest.fixture
+    @pytest.fixture()
     def entity_factory_spy(self, entities):
         return MagicMock(name="entity_factory_spy", side_effect=entities.values())
 
-    @pytest.fixture
+    @pytest.fixture()
     def factory(self, gateway_spy, entity_factory_spy):
         return flag_manager.FlagManagerFactory(gateway_spy, entity_factory_spy)
 

--- a/tests/unit/entities/test_link.py
+++ b/tests/unit/entities/test_link.py
@@ -15,7 +15,7 @@ from .assignments import create_assignments, create_identifier, create_identifie
 class TestCreateLink:
     @staticmethod
     @pytest.mark.parametrize(
-        "state,expected",
+        ("state", "expected"),
         [
             (states.Idle, create_identifiers("1")),
             (states.Activated, create_identifiers("2", "7")),
@@ -45,7 +45,7 @@ class TestCreateLink:
 
     @staticmethod
     @pytest.mark.parametrize(
-        "processes,expectation",
+        ("processes", "expectation"),
         [
             (
                 {Processes.PULL: create_identifiers("1"), Processes.DELETE: create_identifiers("1")},
@@ -85,7 +85,7 @@ class TestCreateLink:
         assert {(entity.identifier, entity.current_process) for entity in link[Components.SOURCE]} == set(expected)
 
     @staticmethod
-    @pytest.mark.parametrize("tainted_identifiers,is_tainted", [(create_identifiers("1"), True), (set(), False)])
+    @pytest.mark.parametrize(("tainted_identifiers", "is_tainted"), [(create_identifiers("1"), True), (set(), False)])
     def test_tainted_attribute_is_set(tainted_identifiers: Iterable[Identifier], is_tainted: bool) -> None:
         link = create_link(create_assignments({Components.SOURCE: {"1"}}), tainted_identifiers=tainted_identifiers)
         entity = next(iter(link[Components.SOURCE]))
@@ -93,7 +93,7 @@ class TestCreateLink:
 
     @staticmethod
     @pytest.mark.parametrize(
-        "assignments,expectation",
+        ("assignments", "expectation"),
         [
             (create_assignments(), pytest.raises(AssertionError)),
             (
@@ -116,7 +116,7 @@ class TestCreateLink:
 
     @staticmethod
     @pytest.mark.parametrize(
-        "assignments,expectation",
+        ("assignments", "expectation"),
         [
             (create_assignments({Components.OUTBOUND: {"1"}, Components.LOCAL: {"1"}}), pytest.raises(AssertionError)),
             (create_assignments(), does_not_raise()),
@@ -131,7 +131,7 @@ class TestCreateLink:
 
     @staticmethod
     @pytest.mark.parametrize(
-        "processes,assignments,expectation",
+        ("processes", "assignments", "expectation"),
         [
             ({}, create_assignments({Components.LOCAL: {"1"}}), pytest.raises(AssertionError)),
             ({}, create_assignments(), does_not_raise()),
@@ -153,7 +153,7 @@ class TestCreateLink:
 
 class TestLink:
     @staticmethod
-    @pytest.fixture
+    @pytest.fixture()
     def assignments() -> dict[Components, set[Identifier]]:
         return create_assignments({Components.SOURCE: {"1", "2"}, Components.OUTBOUND: {"1"}, Components.LOCAL: {"1"}})
 
@@ -173,7 +173,7 @@ class TestLink:
 class TestTransfer:
     @staticmethod
     @pytest.mark.parametrize(
-        "origin,expectation",
+        ("origin", "expectation"),
         [
             (Components.SOURCE, does_not_raise()),
             (Components.OUTBOUND, pytest.raises(AssertionError)),
@@ -186,7 +186,7 @@ class TestTransfer:
 
     @staticmethod
     @pytest.mark.parametrize(
-        "destination,identifier_only,expectation",
+        ("destination", "identifier_only", "expectation"),
         [
             (Components.SOURCE, False, pytest.raises(AssertionError)),
             (Components.OUTBOUND, True, does_not_raise()),
@@ -201,7 +201,7 @@ class TestTransfer:
 
     @staticmethod
     @pytest.mark.parametrize(
-        "destination,identifier_only,expectation",
+        ("destination", "identifier_only", "expectation"),
         [
             (Components.OUTBOUND, False, pytest.raises(AssertionError)),
             (Components.LOCAL, False, does_not_raise()),
@@ -219,7 +219,7 @@ class TestTransfer:
 class TestPullLegacy:
     @staticmethod
     @pytest.mark.parametrize(
-        "assignments,requested,expectation",
+        ("assignments", "requested", "expectation"),
         [
             (
                 create_assignments({Components.SOURCE: {"1"}}),
@@ -245,7 +245,7 @@ class TestPullLegacy:
 
     @staticmethod
     @pytest.mark.parametrize(
-        "assignments,requested,expectation",
+        ("assignments", "requested", "expectation"),
         [
             (
                 create_assignments({Components.SOURCE: {"1"}, Components.OUTBOUND: {"1"}, Components.LOCAL: {"1"}}),
@@ -302,14 +302,15 @@ def test_process_produces_correct_transitions() -> None:
 
 class TestPull:
     @staticmethod
-    @pytest.fixture
+    @pytest.fixture()
     def link() -> Link:
         return create_link(create_assignments({Components.SOURCE: {"1"}}))
 
     @staticmethod
     def test_idle_entity_becomes_activated(link: Link) -> None:
         update = next(iter(pull(link, requested=create_identifiers("1"))))
-        assert {update.identifier} == create_identifiers("1") and update.transition.new is states.Activated
+        assert {update.identifier} == create_identifiers("1")
+        assert update.transition.new is states.Activated
 
     @staticmethod
     def test_not_specifying_requested_identifiers_raises_error(link: Link) -> None:
@@ -322,7 +323,7 @@ class TestPull:
             pull(link, requested=create_identifiers("2"))
 
 
-@pytest.fixture
+@pytest.fixture()
 def link() -> Link:
     return create_link(
         create_assignments({Components.SOURCE: {"1"}, Components.OUTBOUND: {"1"}, Components.LOCAL: {"1"}})
@@ -333,7 +334,8 @@ class TestDelete:
     @staticmethod
     def test_pulled_entity_becomes_received(link: Link) -> None:
         update = next(iter(delete(link, requested=create_identifiers("1"))))
-        assert {update.identifier} == create_identifiers("1") and update.transition.new is states.Received
+        assert {update.identifier} == create_identifiers("1")
+        assert update.transition.new is states.Received
 
     @staticmethod
     def test_not_specifying_requested_identifiers_raises_error(link: Link) -> None:
@@ -350,7 +352,8 @@ class TestFlag:
     @staticmethod
     def test_pulled_entity_becomes_tainted(link: Link) -> None:
         update = next(iter(flag(link, requested=create_identifiers("1"))))
-        assert {update.identifier} == create_identifiers("1") and update.transition.new is states.Tainted
+        assert {update.identifier} == create_identifiers("1")
+        assert update.transition.new is states.Tainted
 
     @staticmethod
     def test_not_specifying_requested_identifiers_raises_error(link: Link) -> None:
@@ -365,14 +368,15 @@ class TestFlag:
 
 class TestUnflag:
     @staticmethod
-    @pytest.fixture
+    @pytest.fixture()
     def link() -> Link:
         return create_link(create_assignments({Components.SOURCE: {"1"}}), tainted_identifiers=create_identifiers("1"))
 
     @staticmethod
     def test_deprecated_entity_becomes_idle(link: Link) -> None:
         update = next(iter(unflag(link, requested=create_identifiers("1"))))
-        assert {update.identifier} == create_identifiers("1") and update.transition.new is states.Idle
+        assert {update.identifier} == create_identifiers("1")
+        assert update.transition.new is states.Idle
 
     @staticmethod
     def test_not_specifying_requested_identifiers_raises_error(link: Link) -> None:

--- a/tests/unit/entities/test_repository.py
+++ b/tests/unit/entities/test_repository.py
@@ -11,13 +11,13 @@ from dj_link.entities.flag_manager import FlagManagerFactory
 from dj_link.entities.repository import Entity, EntityFactory, Repository, RepositoryFactory, TransferEntity
 
 
-@pytest.fixture
+@pytest.fixture()
 def entity_dto_spy():
     return create_autospec(AbstractEntityDTO, instance=True)
 
 
 class TestEntity:
-    @pytest.fixture
+    @pytest.fixture()
     def entity(self, identifier, flags):
         return Entity(identifier, flags)
 
@@ -35,7 +35,7 @@ class TestEntity:
 
 
 class TestTransferEntity:
-    @pytest.fixture
+    @pytest.fixture()
     def transfer_entity(self, identifier, flags, entity_dto_spy):
         return TransferEntity(identifier, flags, entity_dto_spy)
 
@@ -63,7 +63,7 @@ class TestTransferEntity:
 
 
 class TestEntityFactory:
-    @pytest.fixture
+    @pytest.fixture()
     def factory(self, gateway_spy):
         return EntityFactory(gateway_spy)
 
@@ -82,18 +82,18 @@ class TestEntityFactory:
 
 
 class TestRepository:
-    @pytest.fixture
+    @pytest.fixture()
     def contents_spy(self):
         spy = create_autospec(Contents, instance=True)
         spy.__iter__.return_value = "iterator"
         spy.__len__.return_value = 10
         return spy
 
-    @pytest.fixture
+    @pytest.fixture()
     def flag_manager_factory_spy(self):
         return create_autospec(FlagManagerFactory, instance=True)
 
-    @pytest.fixture
+    @pytest.fixture()
     def repo(self, contents_spy, flag_manager_factory_spy, gateway_spy):
         return Repository(contents_spy, flag_manager_factory_spy, gateway_spy)
 
@@ -163,11 +163,11 @@ class TestRepository:
 
 
 class TestRepositoryFactory:
-    @pytest.fixture
+    @pytest.fixture()
     def storage(self):
         return dict()
 
-    @pytest.fixture
+    @pytest.fixture()
     def factory(self, gateway_spy, storage):
         return RepositoryFactory(gateway_spy)
 

--- a/tests/unit/entities/test_state.py
+++ b/tests/unit/entities/test_state.py
@@ -12,7 +12,7 @@ from .assignments import create_assignments, create_identifier, create_identifie
 
 
 @pytest.mark.parametrize(
-    "identifier,state,methods",
+    ("identifier", "state", "methods"),
     [
         (create_identifier("1"), states.Idle, ["delete", "process", "flag", "unflag"]),
         (create_identifier("2"), states.Activated, ["pull", "delete", "flag", "unflag"]),
@@ -49,7 +49,7 @@ def test_pulling_idle_entity_returns_correct_commands() -> None:
 
 
 @pytest.mark.parametrize(
-    "process,tainted_identifiers,new_state,commands",
+    ("process", "tainted_identifiers", "new_state", "commands"),
     [
         (Processes.PULL, set(), states.Received, {Commands.ADD_TO_LOCAL}),
         (Processes.DELETE, set(), states.Idle, {Commands.FINISH_DELETE_PROCESS}),
@@ -76,7 +76,7 @@ def test_processing_activated_entity_returns_correct_commands(
 
 
 @pytest.mark.parametrize(
-    "process,new_state,commands",
+    ("process", "new_state", "commands"),
     [
         (Processes.PULL, states.Pulled, {Commands.FINISH_PULL_PROCESS}),
         (Processes.DELETE, states.Activated, {Commands.REMOVE_FROM_LOCAL}),

--- a/tests/unit/frameworks/datajoint/test_dj_helpers.py
+++ b/tests/unit/frameworks/datajoint/test_dj_helpers.py
@@ -28,13 +28,13 @@ class TestReplaceStores:
         return dict(replacement_pa_store="original_pa_store")
 
     @pytest.fixture()
-    def add_store(self, original_definition_lines, expected_definition_lines, stores):
+    def _add_store(self, original_definition_lines, expected_definition_lines, stores):
         original_definition_lines.append("pb: attach@original_pb_store")
         expected_definition_lines.append("pb: attach@replacement_pb_store")
         stores["replacement_pb_store"] = "original_pb_store"
 
     @pytest.fixture()
-    def add_store_name_outside_of_attached_attribute(
+    def _add_store_name_outside_of_attached_attribute(
         self, original_definition_lines, expected_definition_lines, stores
     ):
         original_definition_lines.append("pc: int # original_pc_store")
@@ -42,7 +42,7 @@ class TestReplaceStores:
         stores["original_pc_store"] = "replacement_pc_store"
 
     @pytest.fixture()
-    def add_store_not_present_in_stores_mapping(self, original_definition_lines, expected_definition_lines):
+    def _add_store_not_present_in_stores_mapping(self, original_definition_lines, expected_definition_lines):
         original_definition_lines.append("pc: attach@original_pc_store")
         expected_definition_lines.append("pc: attach@original_pc_store")
 
@@ -62,29 +62,29 @@ class TestReplaceStores:
     def test_if_single_store_is_replaced(self, replacement_matches_expectation):
         assert replacement_matches_expectation()
 
-    @pytest.mark.usefixtures("add_store")
+    @pytest.mark.usefixtures("_add_store")
     def test_if_multiple_stores_are_replaced(self, replacement_matches_expectation):
         assert replacement_matches_expectation()
 
-    @pytest.mark.usefixtures("add_store_name_outside_of_attached_attribute")
+    @pytest.mark.usefixtures("_add_store_name_outside_of_attached_attribute")
     def test_if_store_names_outside_of_attached_attributes_are_ignored(self, replacement_matches_expectation):
         assert replacement_matches_expectation()
 
-    @pytest.mark.usefixtures("add_store_not_present_in_stores_mapping")
+    @pytest.mark.usefixtures("_add_store_not_present_in_stores_mapping")
     def test_if_stores_not_present_in_stores_mapping_are_ignored(self, replacement_matches_expectation):
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
             assert replacement_matches_expectation()
 
-    @pytest.mark.usefixtures("add_store_not_present_in_stores_mapping")
+    @pytest.mark.usefixtures("_add_store_not_present_in_stores_mapping")
     def test_if_user_warning_is_raised_if_stores_missing_in_stores_mapping_are_encountered(self, recorded_warnings):
         pass
 
-    @pytest.mark.usefixtures("add_store_not_present_in_stores_mapping")
+    @pytest.mark.usefixtures("_add_store_not_present_in_stores_mapping")
     def test_if_only_one_warning_is_raised(self, recorded_warnings):
         assert len(recorded_warnings) == 1
 
-    @pytest.mark.usefixtures("add_store_not_present_in_stores_mapping")
+    @pytest.mark.usefixtures("_add_store_not_present_in_stores_mapping")
     def test_if_warning_message_is_correct(self, recorded_warnings):
         assert (
             recorded_warnings[0].message.args[0] == "No replacement for store 'original_pc_store' specified. Skipping!"
@@ -114,7 +114,7 @@ class TestGetPartTableClasses:
         return Table
 
     @pytest.fixture()
-    def add_part_table_class(self, part_table_classes):
+    def _add_part_table_class(self, part_table_classes):
         part_table_classes["PartB"] = type("PartB", (Part,), dict())
 
     @pytest.fixture()
@@ -122,18 +122,18 @@ class TestGetPartTableClasses:
         return []
 
     @pytest.fixture()
-    def add_ignored_part_table(self, other_attrs, ignored_parts):
+    def _add_ignored_part_table(self, other_attrs, ignored_parts):
         name = "IgnoredPart"
         other_attrs[name] = type(name, (Part,), dict())
         ignored_parts.append(name)
 
     @pytest.fixture()
-    def add_non_part_class(self, other_attrs):
+    def _add_non_part_class(self, other_attrs):
         name = "NotAPart"
         other_attrs[name] = type(name, tuple(), dict())
 
     @pytest.fixture()
-    def add_non_class_attr(self, other_attrs):
+    def _add_non_class_attr(self, other_attrs):
         other_attrs["NotAClass"] = "NotAClass"
 
     @pytest.fixture()
@@ -141,7 +141,7 @@ class TestGetPartTableClasses:
         return dj_helpers.get_part_table_classes(table_cls, ignored_parts=ignored_parts) == part_table_classes
 
     @pytest.fixture()
-    def add_lowercase_part_table_class(self, other_attrs):
+    def _add_lowercase_part_table_class(self, other_attrs):
         name = "lowercase_part"
         other_attrs[name] = type(name, (Part,), dict())
 
@@ -151,22 +151,22 @@ class TestGetPartTableClasses:
     def test_if_single_part_table_is_found(self, correct_part_tables_returned):
         assert correct_part_tables_returned
 
-    @pytest.mark.usefixtures("add_part_table_class")
+    @pytest.mark.usefixtures("_add_part_table_class")
     def test_if_multiple_part_tables_are_found(self, correct_part_tables_returned):
         assert correct_part_tables_returned
 
-    @pytest.mark.usefixtures("add_ignored_part_table")
+    @pytest.mark.usefixtures("_add_ignored_part_table")
     def test_if_ignored_part_tables_are_ignored(self, correct_part_tables_returned):
         assert correct_part_tables_returned
 
-    @pytest.mark.usefixtures("add_non_part_class")
+    @pytest.mark.usefixtures("_add_non_part_class")
     def test_if_non_part_classes_are_ignored(self, correct_part_tables_returned):
         assert correct_part_tables_returned
 
-    @pytest.mark.usefixtures("add_non_class_attr")
+    @pytest.mark.usefixtures("_add_non_class_attr")
     def test_if_non_class_attrs_are_ignored(self, correct_part_tables_returned):
         assert correct_part_tables_returned
 
-    @pytest.mark.usefixtures("add_lowercase_part_table_class")
+    @pytest.mark.usefixtures("_add_lowercase_part_table_class")
     def test_if_lowercase_part_table_classes_are_ignored(self, correct_part_tables_returned):
         assert correct_part_tables_returned

--- a/tests/unit/frameworks/datajoint/test_dj_helpers.py
+++ b/tests/unit/frameworks/datajoint/test_dj_helpers.py
@@ -7,33 +7,33 @@ from dj_link.frameworks.datajoint import dj_helpers
 
 
 class TestReplaceStores:
-    @pytest.fixture
+    @pytest.fixture()
     def original_definition_lines(self):
         return ["pa : attach@original_pa_store"]
 
-    @pytest.fixture
+    @pytest.fixture()
     def original_definition(self, original_definition_lines):
         return "\n".join(original_definition_lines)
 
-    @pytest.fixture
+    @pytest.fixture()
     def expected_definition_lines(self):
         return ["pa : attach@replacement_pa_store"]
 
-    @pytest.fixture
+    @pytest.fixture()
     def expected_definition(self, expected_definition_lines):
         return "\n".join(expected_definition_lines)
 
-    @pytest.fixture
+    @pytest.fixture()
     def stores(self):
         return dict(replacement_pa_store="original_pa_store")
 
-    @pytest.fixture
+    @pytest.fixture()
     def add_store(self, original_definition_lines, expected_definition_lines, stores):
         original_definition_lines.append("pb: attach@original_pb_store")
         expected_definition_lines.append("pb: attach@replacement_pb_store")
         stores["replacement_pb_store"] = "original_pb_store"
 
-    @pytest.fixture
+    @pytest.fixture()
     def add_store_name_outside_of_attached_attribute(
         self, original_definition_lines, expected_definition_lines, stores
     ):
@@ -41,19 +41,19 @@ class TestReplaceStores:
         expected_definition_lines.append("pc: int # original_pc_store")
         stores["original_pc_store"] = "replacement_pc_store"
 
-    @pytest.fixture
+    @pytest.fixture()
     def add_store_not_present_in_stores_mapping(self, original_definition_lines, expected_definition_lines):
         original_definition_lines.append("pc: attach@original_pc_store")
         expected_definition_lines.append("pc: attach@original_pc_store")
 
-    @pytest.fixture
+    @pytest.fixture()
     def replacement_matches_expectation(self, original_definition, expected_definition, stores):
         def _replacement_matches_expectation():
             return dj_helpers.replace_stores(original_definition, stores) == expected_definition
 
         return _replacement_matches_expectation
 
-    @pytest.fixture
+    @pytest.fixture()
     def recorded_warnings(self, original_definition, stores):
         with pytest.warns(UserWarning) as record:
             dj_helpers.replace_stores(original_definition, stores)
@@ -92,19 +92,19 @@ class TestReplaceStores:
 
 
 class TestGetPartTableClasses:
-    @pytest.fixture
+    @pytest.fixture()
     def part_table_classes(self):
         return dict(PartA=type("PartA", (Part,), dict()))
 
-    @pytest.fixture
+    @pytest.fixture()
     def other_attrs(self):
         return dict()
 
-    @pytest.fixture
+    @pytest.fixture()
     def attrs(self, part_table_classes, other_attrs):
         return {**part_table_classes, **other_attrs}
 
-    @pytest.fixture
+    @pytest.fixture()
     def table_cls(self, attrs):
         class Table:
             pass
@@ -113,34 +113,34 @@ class TestGetPartTableClasses:
             setattr(Table, name, attr)
         return Table
 
-    @pytest.fixture
+    @pytest.fixture()
     def add_part_table_class(self, part_table_classes):
         part_table_classes["PartB"] = type("PartB", (Part,), dict())
 
-    @pytest.fixture
+    @pytest.fixture()
     def ignored_parts(self):
         return []
 
-    @pytest.fixture
+    @pytest.fixture()
     def add_ignored_part_table(self, other_attrs, ignored_parts):
         name = "IgnoredPart"
         other_attrs[name] = type(name, (Part,), dict())
         ignored_parts.append(name)
 
-    @pytest.fixture
+    @pytest.fixture()
     def add_non_part_class(self, other_attrs):
         name = "NotAPart"
         other_attrs[name] = type(name, tuple(), dict())
 
-    @pytest.fixture
+    @pytest.fixture()
     def add_non_class_attr(self, other_attrs):
         other_attrs["NotAClass"] = "NotAClass"
 
-    @pytest.fixture
+    @pytest.fixture()
     def correct_part_tables_returned(self, table_cls, part_table_classes, ignored_parts):
         return dj_helpers.get_part_table_classes(table_cls, ignored_parts=ignored_parts) == part_table_classes
 
-    @pytest.fixture
+    @pytest.fixture()
     def add_lowercase_part_table_class(self, other_attrs):
         name = "lowercase_part"
         other_attrs[name] = type(name, (Part,), dict())

--- a/tests/unit/frameworks/datajoint/test_facade.py
+++ b/tests/unit/frameworks/datajoint/test_facade.py
@@ -11,32 +11,32 @@ from dj_link.frameworks.datajoint.factory import TableFactory
 from dj_link.frameworks.datajoint.file import ReusableTemporaryDirectory
 
 
-@pytest.fixture
+@pytest.fixture()
 def primary_key_names():
     return ["a", "b"]
 
 
-@pytest.fixture
+@pytest.fixture()
 def primary_key(primary_key_names):
     return {name: i for i, name in enumerate(primary_key_names)}
 
 
-@pytest.fixture
+@pytest.fixture()
 def master_entity(primary_key):
     return dict(primary_key, non_primary_attr1=0, non_primary_attr2=1)
 
 
-@pytest.fixture
+@pytest.fixture()
 def flag_table_names():
     return ["MyFlag", "MyOtherFlag"]
 
 
-@pytest.fixture
+@pytest.fixture()
 def is_present_in_flag_table(flag_table_names):
     return {flag_table_name: is_present for flag_table_name, is_present in zip(flag_table_names, [False, True])}
 
 
-@pytest.fixture
+@pytest.fixture()
 def flag_table_spies(flag_table_names, is_present_in_flag_table):
     flag_table_spies = {}
     for name in flag_table_names:
@@ -46,7 +46,7 @@ def flag_table_spies(flag_table_names, is_present_in_flag_table):
     return flag_table_spies
 
 
-@pytest.fixture
+@pytest.fixture()
 def table_spy(primary_key_names, flag_table_spies, master_entity):
     table_spy = create_autospec(Table, flag_table_names=flag_table_names, primary_key=primary_key_names)
     table_spy.proj.return_value.fetch.return_value = "primary_keys"
@@ -60,12 +60,12 @@ def table_spy(primary_key_names, flag_table_spies, master_entity):
     return table_spy
 
 
-@pytest.fixture
+@pytest.fixture()
 def part_entities():
     return {name: name + "_entities" for name in ["MyPart", "MyOtherPart"]}
 
 
-@pytest.fixture
+@pytest.fixture()
 def part_table_spies(part_entities):
     part_table_spies = {}
     for name, entities in part_entities.items():
@@ -75,7 +75,7 @@ def part_table_spies(part_entities):
     return part_table_spies
 
 
-@pytest.fixture
+@pytest.fixture()
 def table_factory_spy(table_spy, part_table_spies, flag_table_spies):
     return MagicMock(
         name="table_factory_spy",
@@ -86,14 +86,14 @@ def table_factory_spy(table_spy, part_table_spies, flag_table_spies):
     )
 
 
-@pytest.fixture
+@pytest.fixture()
 def temp_dir_stub():
     stub = create_autospec(ReusableTemporaryDirectory, instance=True)
     stub.name = "temp_dir"
     return stub
 
 
-@pytest.fixture
+@pytest.fixture()
 def table_facade(table_factory_spy, temp_dir_stub):
     return TableFacade(table_factory_spy, temp_dir_stub)
 
@@ -110,7 +110,7 @@ def test_if_temp_dir_is_stored_as_instance_attribute(table_facade, temp_dir_stub
     assert table_facade.temp_dir == temp_dir_stub
 
 
-@pytest.fixture
+@pytest.fixture()
 def primary_keys_in_restriction(table_facade):
     return table_facade.get_primary_keys_in_restriction("restriction")
 
@@ -133,7 +133,7 @@ class TestGetPrimaryKeysInRestriction:
         assert primary_keys_in_restriction == "primary_keys_in_restriction"
 
 
-@pytest.fixture
+@pytest.fixture()
 def flags(table_facade, primary_key):
     return table_facade.get_flags(primary_key)
 
@@ -153,7 +153,7 @@ class TestGetFlags:
 
 
 class TestFetch:
-    @pytest.fixture
+    @pytest.fixture()
     def fetched_entity(self, table_facade, primary_key):
         return table_facade.fetch(primary_key)
 
@@ -192,11 +192,11 @@ class TestFetch:
 
 
 class TestInsert:
-    @pytest.fixture
+    @pytest.fixture()
     def insert(self, table_facade, entity_dto):
         table_facade.insert(entity_dto)
 
-    @pytest.fixture
+    @pytest.fixture()
     def entity_dto(self, primary_key_names, master_entity, part_entities):
         # noinspection PyArgumentList
         return EntityDTO(primary_key_names, master_entity, parts=part_entities)
@@ -227,7 +227,7 @@ class TestInsert:
 
 
 class TestDelete:
-    @pytest.fixture
+    @pytest.fixture()
     def delete(self, table_facade, primary_key):
         table_facade.delete(primary_key)
 
@@ -267,12 +267,12 @@ class TestDelete:
             part.__and__.return_value.delete_quick.assert_called_once_with()
 
 
-@pytest.fixture
+@pytest.fixture()
 def flag_table_name(flag_table_names):
     return flag_table_names[0]
 
 
-@pytest.fixture
+@pytest.fixture()
 def flag_table_spy(flag_table_spies, flag_table_name):
     return flag_table_spies[flag_table_name]
 
@@ -282,7 +282,7 @@ def test_if_flag_is_enabled(table_facade, primary_key, flag_table_name, flag_tab
     flag_table_spy.insert1.assert_called_once_with(primary_key)
 
 
-@pytest.fixture
+@pytest.fixture()
 def disable_flag(table_facade, primary_key, flag_table_name):
     table_facade.disable_flag(primary_key, flag_table_name)
 
@@ -296,7 +296,7 @@ class TestDisableFlag:
         flag_table_spy.__and__.return_value.delete_quick.assert_called_once_with()
 
 
-@pytest.fixture
+@pytest.fixture()
 def execute(request, table_facade):
     getattr(table_facade, request.cls.method_name)()
 

--- a/tests/unit/frameworks/datajoint/test_facade.py
+++ b/tests/unit/frameworks/datajoint/test_facade.py
@@ -193,7 +193,7 @@ class TestFetch:
 
 class TestInsert:
     @pytest.fixture()
-    def insert(self, table_facade, entity_dto):
+    def _insert(self, table_facade, entity_dto):
         table_facade.insert(entity_dto)
 
     @pytest.fixture()
@@ -201,15 +201,15 @@ class TestInsert:
         # noinspection PyArgumentList
         return EntityDTO(primary_key_names, master_entity, parts=part_entities)
 
-    @pytest.mark.usefixtures("insert")
+    @pytest.mark.usefixtures("_insert")
     def test_if_call_to_table_factory_is_correct(self, table_factory_spy):
         table_factory_spy.assert_called_once_with()
 
-    @pytest.mark.usefixtures("insert")
+    @pytest.mark.usefixtures("_insert")
     def test_if_master_entity_is_inserted(self, table_spy, master_entity):
         table_spy.insert1.assert_called_once_with(master_entity)
 
-    @pytest.mark.usefixtures("insert")
+    @pytest.mark.usefixtures("_insert")
     def test_if_part_entities_are_inserted(self, part_table_spies, part_entities):
         for name, part in part_table_spies.items():
             part.insert.assert_called_once_with(part_entities[name])
@@ -228,30 +228,30 @@ class TestInsert:
 
 class TestDelete:
     @pytest.fixture()
-    def delete(self, table_facade, primary_key):
+    def _delete(self, table_facade, primary_key):
         table_facade.delete(primary_key)
 
-    @pytest.mark.usefixtures("delete")
+    @pytest.mark.usefixtures("_delete")
     def test_if_non_flag_part_tables_and_flag_part_tables_are_restricted(
         self, part_table_spies, flag_table_spies, primary_key
     ):
         for part in chain(part_table_spies.values(), flag_table_spies.values()):
             part.__and__.assert_called_once_with(primary_key)
 
-    @pytest.mark.usefixtures("delete")
+    @pytest.mark.usefixtures("_delete")
     def test_if_part_entities_and_flags_are_deleted(self, part_table_spies, flag_table_spies):
         for part in chain(part_table_spies.values(), flag_table_spies.values()):
             part.__and__.return_value.delete_quick.assert_called_once_with()
 
-    @pytest.mark.usefixtures("delete")
+    @pytest.mark.usefixtures("_delete")
     def test_if_call_to_table_factory_is_correct(self, table_factory_spy):
         table_factory_spy.assert_called_once_with()
 
-    @pytest.mark.usefixtures("delete")
+    @pytest.mark.usefixtures("_delete")
     def test_if_table_is_restricted(self, table_spy, primary_key):
         table_spy.__and__.assert_called_once_with(primary_key)
 
-    @pytest.mark.usefixtures("delete")
+    @pytest.mark.usefixtures("_delete")
     def test_if_master_table_entity_is_deleted(self, table_spy):
         table_spy.__and__.return_value.delete_quick.assert_called_once_with()
 
@@ -283,11 +283,11 @@ def test_if_flag_is_enabled(table_facade, primary_key, flag_table_name, flag_tab
 
 
 @pytest.fixture()
-def disable_flag(table_facade, primary_key, flag_table_name):
+def _disable_flag(table_facade, primary_key, flag_table_name):
     table_facade.disable_flag(primary_key, flag_table_name)
 
 
-@pytest.mark.usefixtures("disable_flag")
+@pytest.mark.usefixtures("_disable_flag")
 class TestDisableFlag:
     def test_if_flag_table_is_restricted(self, flag_table_spy, primary_key):
         flag_table_spy.__and__.assert_called_once_with(primary_key)
@@ -297,11 +297,11 @@ class TestDisableFlag:
 
 
 @pytest.fixture()
-def execute(request, table_facade):
+def _execute(request, table_facade):
     getattr(table_facade, request.cls.method_name)()
 
 
-@pytest.mark.usefixtures("execute")
+@pytest.mark.usefixtures("_execute")
 class TestTransaction:
     @pytest.fixture(params=["start_transaction", "commit_transaction", "cancel_transaction"], autouse=True)
     def method_name(self, request):

--- a/tests/unit/frameworks/datajoint/test_factory.py
+++ b/tests/unit/frameworks/datajoint/test_factory.py
@@ -117,7 +117,7 @@ def flag_part_tables(flag_part_table_names):
 
 
 @pytest.fixture()
-def configure_for_spawning(factory, fake_schema, table_name, table_bases, flag_part_table_names):
+def _configure_for_spawning(factory, fake_schema, table_name, table_bases, flag_part_table_names):
     config = create_autospec(TableFactoryConfig, instance=True)
     config.schema = fake_schema
     config.name = table_name
@@ -171,7 +171,7 @@ def dummy_table_cls(table_name, dummy_table_base_cls, part_tables):
 
 
 @pytest.fixture()
-def configure_for_creating(
+def _configure_for_creating(
     factory,
     fake_schema,
     table_name,
@@ -195,7 +195,7 @@ def configure_for_creating(
 
 
 @pytest.fixture()
-def table_can_not_be_spawned(fake_schema):
+def _table_can_not_be_spawned(fake_schema):
     fake_schema.table_classes = set()
 
 
@@ -205,59 +205,59 @@ def returned_non_flag_part_tables(factory, non_flag_part_table_definitions):
 
 
 class TestCall:
-    @pytest.mark.usefixtures("configure_for_spawning")
+    @pytest.mark.usefixtures("_configure_for_spawning")
     def test_if_name_of_spawned_table_class_is_correct(self, factory, table_name):
         assert factory().__name__ == table_name
 
-    @pytest.mark.usefixtures("configure_for_spawning")
+    @pytest.mark.usefixtures("_configure_for_spawning")
     def test_if_spawned_table_class_is_subclass_of_spawned_table_class_table_bases(
         self, factory, dummy_table_cls, table_bases
     ):
         for cls in (dummy_table_cls,) + table_bases:
             assert issubclass(factory(), cls)
 
-    @pytest.mark.usefixtures("configure_for_spawning", "table_can_not_be_spawned")
+    @pytest.mark.usefixtures("_configure_for_spawning", "_table_can_not_be_spawned")
     def test_if_runtime_error_is_raised_if_spawning_fails_and_table_creation_is_not_possible(self, factory):
         with pytest.raises(RuntimeError) as exc_info:
             factory()
         assert str(exc_info.value) == "Table could neither be spawned nor created"
 
-    @pytest.mark.usefixtures("configure_for_creating", "table_can_not_be_spawned")
+    @pytest.mark.usefixtures("_configure_for_creating", "_table_can_not_be_spawned")
     def test_if_created_table_class_is_subclass_of_table_class_and_table_bases(
         self, factory, dummy_table_base_cls, table_bases
     ):
         for cls in (dummy_table_base_cls,) + table_bases:
             assert issubclass(factory(), cls)
 
-    @pytest.mark.usefixtures("configure_for_creating", "table_can_not_be_spawned")
+    @pytest.mark.usefixtures("_configure_for_creating", "_table_can_not_be_spawned")
     def test_if_name_of_created_table_class_is_correct(self, factory, table_name):
         assert factory().__name__ == table_name
 
-    @pytest.mark.usefixtures("configure_for_creating", "table_can_not_be_spawned")
+    @pytest.mark.usefixtures("_configure_for_creating", "_table_can_not_be_spawned")
     def test_if_definition_of_created_table_class_is_correct(self, factory, table_definition):
         assert factory().definition == table_definition
 
-    @pytest.mark.usefixtures("configure_for_creating", "table_can_not_be_spawned")
+    @pytest.mark.usefixtures("_configure_for_creating", "_table_can_not_be_spawned")
     def test_if_flag_tables_are_part_tables(self, factory, flag_part_table_names):
         assert all(issubclass(getattr(factory(), name), Part) for name in flag_part_table_names)
 
-    @pytest.mark.usefixtures("configure_for_creating", "table_can_not_be_spawned")
+    @pytest.mark.usefixtures("_configure_for_creating", "_table_can_not_be_spawned")
     def test_if_names_of_flag_tables_are_correct(self, factory, flag_part_table_names):
         assert all(getattr(factory(), name).__name__ == name for name in flag_part_table_names)
 
-    @pytest.mark.usefixtures("configure_for_creating", "table_can_not_be_spawned")
+    @pytest.mark.usefixtures("_configure_for_creating", "_table_can_not_be_spawned")
     def test_if_definitions_of_flag_tables_are_correct(self, factory, flag_part_table_names):
         assert all(getattr(factory(), name).definition == "-> master" for name in flag_part_table_names)
 
-    @pytest.mark.usefixtures("configure_for_creating", "table_can_not_be_spawned")
+    @pytest.mark.usefixtures("_configure_for_creating", "_table_can_not_be_spawned")
     def test_if_part_tables_are_part_tables(self, returned_non_flag_part_tables):
         assert all(issubclass(part, Part) for part in returned_non_flag_part_tables.values())
 
-    @pytest.mark.usefixtures("configure_for_creating", "table_can_not_be_spawned")
+    @pytest.mark.usefixtures("_configure_for_creating", "_table_can_not_be_spawned")
     def test_if_names_of_non_flag_tables_are_correct(self, returned_non_flag_part_tables):
         assert all(part.__name__ == name for name, part in returned_non_flag_part_tables.items())
 
-    @pytest.mark.usefixtures("configure_for_creating", "table_can_not_be_spawned")
+    @pytest.mark.usefixtures("_configure_for_creating", "_table_can_not_be_spawned")
     def test_if_definitions_of_part_tables_are_correct(
         self, returned_non_flag_part_tables, non_flag_part_table_definitions
     ):
@@ -266,18 +266,18 @@ class TestCall:
             for name, part in returned_non_flag_part_tables.items()
         )
 
-    @pytest.mark.usefixtures("configure_for_creating", "table_can_not_be_spawned")
+    @pytest.mark.usefixtures("_configure_for_creating", "_table_can_not_be_spawned")
     def test_if_schema_is_applied_to_created_table_class(self, factory, fake_schema):
         assert factory().database == fake_schema.database
 
-    @pytest.mark.usefixtures("configure_for_creating", "table_can_not_be_spawned")
+    @pytest.mark.usefixtures("_configure_for_creating", "_table_can_not_be_spawned")
     def test_if_table_base_class_is_subclassed_before_being_passed_to_schema(
         self, factory, fake_schema, dummy_table_base_cls
     ):
         factory()
         assert dummy_table_base_cls not in fake_schema.table_classes
 
-    @pytest.mark.usefixtures("configure_for_creating", "table_can_not_be_spawned")
+    @pytest.mark.usefixtures("_configure_for_creating", "_table_can_not_be_spawned")
     def test_if_factory_passes_context_to_schema(self, factory):
         class ParentTable:
             pass
@@ -288,11 +288,11 @@ class TestCall:
             factory()
 
 
-@pytest.mark.usefixtures("configure_for_spawning")
+@pytest.mark.usefixtures("_configure_for_spawning")
 def test_if_part_tables_attribute_is_correct(factory, non_flag_part_tables):
     assert factory.part_tables == non_flag_part_tables
 
 
-@pytest.mark.usefixtures("configure_for_spawning")
+@pytest.mark.usefixtures("_configure_for_spawning")
 def test_if_flag_tables_attribute_is_correct(factory, flag_part_tables):
     assert factory.flag_tables == flag_part_tables

--- a/tests/unit/frameworks/datajoint/test_factory.py
+++ b/tests/unit/frameworks/datajoint/test_factory.py
@@ -14,7 +14,7 @@ class TestTableFactoryConfig:
     def test_if_dataclass(self):
         assert is_dataclass(TableFactoryConfig)
 
-    @pytest.fixture
+    @pytest.fixture()
     def partial_config_cls(self):
         return partial(TableFactoryConfig, MagicMock(name="dummy_schema"), "table_name")
 
@@ -31,7 +31,7 @@ class TestTableFactoryConfig:
         assert partial_config_cls().part_table_definitions == dict()
 
     @pytest.mark.parametrize(
-        "kwargs,expected",
+        ("kwargs", "expected"),
         [
             ({"tier": TableTiers.LOOKUP, "definition": "definition"}, True),
             ({"definition": "definition"}, False),
@@ -43,7 +43,7 @@ class TestTableFactoryConfig:
         assert partial_config_cls(**kwargs).is_table_creation_possible is expected
 
 
-@pytest.fixture
+@pytest.fixture()
 def factory():
     return TableFactory()
 
@@ -58,7 +58,7 @@ def test_if_runtime_error_is_raised_if_config_is_accessed_while_not_being_set(fa
     assert str(exc_info.value) == "Config is not set"
 
 
-@pytest.fixture
+@pytest.fixture()
 def fake_schema(dummy_table_cls):
     class FakeSchema:
         def __init__(self, table_classes):
@@ -96,27 +96,27 @@ def fake_schema(dummy_table_cls):
     return FakeSchema([dummy_table_cls])
 
 
-@pytest.fixture
+@pytest.fixture()
 def table_name():
     return "Table"
 
 
-@pytest.fixture
+@pytest.fixture()
 def table_bases():
     return tuple(type(name, tuple(), dict()) for name in ("BaseClass", "AnotherBaseClass"))
 
 
-@pytest.fixture
+@pytest.fixture()
 def flag_part_table_names():
     return ["SomeFlagTable", "AnotherFlagTable"]
 
 
-@pytest.fixture
+@pytest.fixture()
 def flag_part_tables(flag_part_table_names):
     return {name: type(name, (Part,), dict(definition="-> master")) for name in flag_part_table_names}
 
 
-@pytest.fixture
+@pytest.fixture()
 def configure_for_spawning(factory, fake_schema, table_name, table_bases, flag_part_table_names):
     config = create_autospec(TableFactoryConfig, instance=True)
     config.schema = fake_schema
@@ -129,7 +129,7 @@ def configure_for_spawning(factory, fake_schema, table_name, table_bases, flag_p
     factory.config = config
 
 
-@pytest.fixture
+@pytest.fixture()
 def dummy_table_base_cls():
     class DummyTableBase:
         pass
@@ -137,22 +137,22 @@ def dummy_table_base_cls():
     return DummyTableBase
 
 
-@pytest.fixture
+@pytest.fixture()
 def table_definition():
     return "some definition"
 
 
-@pytest.fixture
+@pytest.fixture()
 def non_flag_part_table_names():
     return ["SomePartTable", "AnotherPartTable"]
 
 
-@pytest.fixture
+@pytest.fixture()
 def non_flag_part_table_definitions(non_flag_part_table_names):
     return {name: name + "_definition" for name in non_flag_part_table_names}
 
 
-@pytest.fixture
+@pytest.fixture()
 def non_flag_part_tables(non_flag_part_table_definitions):
     return {
         name: type(name, (Part,), dict(definition=definition))
@@ -160,17 +160,17 @@ def non_flag_part_tables(non_flag_part_table_definitions):
     }
 
 
-@pytest.fixture
+@pytest.fixture()
 def part_tables(flag_part_tables, non_flag_part_tables):
     return {**flag_part_tables, **non_flag_part_tables}
 
 
-@pytest.fixture
+@pytest.fixture()
 def dummy_table_cls(table_name, dummy_table_base_cls, part_tables):
     return type(table_name, (dummy_table_base_cls,), part_tables)
 
 
-@pytest.fixture
+@pytest.fixture()
 def configure_for_creating(
     factory,
     fake_schema,
@@ -194,12 +194,12 @@ def configure_for_creating(
     factory.config = config
 
 
-@pytest.fixture
+@pytest.fixture()
 def table_can_not_be_spawned(fake_schema):
     fake_schema.table_classes = set()
 
 
-@pytest.fixture
+@pytest.fixture()
 def returned_non_flag_part_tables(factory, non_flag_part_table_definitions):
     return {name: getattr(factory(), name) for name in non_flag_part_table_definitions}
 

--- a/tests/unit/frameworks/datajoint/test_file.py
+++ b/tests/unit/frameworks/datajoint/test_file.py
@@ -20,19 +20,19 @@ def test_if_temporary_directory_class_is_correct():
     assert ReusableTemporaryDirectory.temp_dir_cls is TemporaryDirectory
 
 
-@pytest.fixture
+@pytest.fixture()
 def temp_dir_spy():
     spy = create_autospec(TemporaryDirectory, instance=True)
     spy.name = "temp_dir"
     return spy
 
 
-@pytest.fixture
+@pytest.fixture()
 def temp_dir_cls_spy(temp_dir_spy):
     return create_autospec(TemporaryDirectory, return_value=temp_dir_spy)
 
 
-@pytest.fixture
+@pytest.fixture()
 def reusable_temp_dir(temp_dir_cls_spy):
     temp_dir = ReusableTemporaryDirectory("prefix")
     temp_dir.temp_dir_cls = temp_dir_cls_spy

--- a/tests/unit/frameworks/datajoint/test_link.py
+++ b/tests/unit/frameworks/datajoint/test_link.py
@@ -7,7 +7,7 @@ from dj_link.frameworks.datajoint.factory import TableFactory, TableFactoryConfi
 from dj_link.frameworks.datajoint.link import LocalTableCreator
 
 
-@pytest.fixture
+@pytest.fixture()
 def schema_cls_stub():
     class SchemaStub:
         def __init__(self, schema_name, connection):
@@ -17,39 +17,39 @@ def schema_cls_stub():
     return SchemaStub
 
 
-@pytest.fixture
+@pytest.fixture()
 def local_schema_stub(schema_cls_stub):
     return schema_cls_stub("local_schema", "local_connection")
 
 
-@pytest.fixture
+@pytest.fixture()
 def source_schema_stub(schema_cls_stub):
     return schema_cls_stub("source_schema", "source_connection")
 
 
-@pytest.fixture
+@pytest.fixture()
 def stores():
     return dict(source_store="local_store")
 
 
-@pytest.fixture
+@pytest.fixture()
 def schema_cls_spy():
     return MagicMock(name="schema_cls_spy")
 
 
-@pytest.fixture
+@pytest.fixture()
 def replace_stores_spy():
     return MagicMock(name="replace_stores_spy", return_value="replaced_heading")
 
 
-@pytest.fixture
+@pytest.fixture()
 def source_table_cls_stub():
     source_table_stub = MagicMock(name="source_table_cls_stub")
     source_table_stub.return_value.heading.__str__.return_value = "source_master_heading"
     return source_table_stub
 
 
-@pytest.fixture
+@pytest.fixture()
 def source_part_stubs():
     source_part_stubs = {}
     for name in ["A", "B", "C"]:
@@ -59,7 +59,7 @@ def source_part_stubs():
     return source_part_stubs
 
 
-@pytest.fixture
+@pytest.fixture()
 def table_cls_factory_spies(source_table_cls_stub, source_part_stubs):
     table_cls_factory_spies = {
         kind: MagicMock(name=kind + "_dummy_table_cls_factory", spec=TableFactory)
@@ -72,12 +72,12 @@ def table_cls_factory_spies(source_table_cls_stub, source_part_stubs):
     return table_cls_factory_spies
 
 
-@pytest.fixture
+@pytest.fixture()
 def dummy_base_table_cls():
     return MagicMock(name="dummy_base_table_cls")
 
 
-@pytest.fixture
+@pytest.fixture()
 def dummy_local_table_mixin():
     class DummyLocalTableMixin:
         pass
@@ -85,7 +85,7 @@ def dummy_local_table_mixin():
     return DummyLocalTableMixin
 
 
-@pytest.fixture
+@pytest.fixture()
 def link(
     local_schema_stub,
     source_schema_stub,
@@ -107,29 +107,29 @@ def link(
     return creator
 
 
-@pytest.fixture
+@pytest.fixture()
 def table_name():
     return "table"
 
 
-@pytest.fixture
+@pytest.fixture()
 def dummy_cls(table_name):
     return MagicMock(name="dummy_cls", __name__=table_name)
 
 
-@pytest.fixture
+@pytest.fixture()
 def prepare_env():
     os.environ["LINK_OUTBOUND"] = "outbound_schema"
     yield
     del os.environ["LINK_OUTBOUND"]
 
 
-@pytest.fixture
+@pytest.fixture()
 def linked_table(link, dummy_cls):
     return link.create(dummy_cls.__name__)
 
 
-@pytest.fixture
+@pytest.fixture()
 def basic_outbound_config(table_name, schema_cls_spy):
     return dict(
         schema=schema_cls_spy.return_value,
@@ -138,7 +138,7 @@ def basic_outbound_config(table_name, schema_cls_spy):
     )
 
 
-@pytest.fixture
+@pytest.fixture()
 def basic_local_config(local_schema_stub, table_name, dummy_local_table_mixin):
     return dict(
         schema=local_schema_stub,
@@ -170,7 +170,7 @@ class TestCallWithoutInitialSetup:
         assert linked_table == "local_table_cls"
 
 
-@pytest.fixture
+@pytest.fixture()
 def initial_setup_required(table_cls_factory_spies):
     table_cls_factory_spies["local"].side_effect = [RuntimeError, "local_table_cls"]
 

--- a/tests/unit/frameworks/datajoint/test_link.py
+++ b/tests/unit/frameworks/datajoint/test_link.py
@@ -118,7 +118,7 @@ def dummy_cls(table_name):
 
 
 @pytest.fixture()
-def prepare_env():
+def _prepare_env():
     os.environ["LINK_OUTBOUND"] = "outbound_schema"
     yield
     del os.environ["LINK_OUTBOUND"]
@@ -148,7 +148,7 @@ def basic_local_config(local_schema_stub, table_name, dummy_local_table_mixin):
     )
 
 
-@pytest.mark.usefixtures("prepare_env", "linked_table")
+@pytest.mark.usefixtures("_prepare_env", "linked_table")
 class TestCallWithoutInitialSetup:
     def test_if_configuration_of_source_table_cls_factory_is_correct(
         self, table_cls_factory_spies, source_schema_stub, table_name
@@ -171,11 +171,11 @@ class TestCallWithoutInitialSetup:
 
 
 @pytest.fixture()
-def initial_setup_required(table_cls_factory_spies):
+def _initial_setup_required(table_cls_factory_spies):
     table_cls_factory_spies["local"].side_effect = [RuntimeError, "local_table_cls"]
 
 
-@pytest.mark.usefixtures("prepare_env", "initial_setup_required", "linked_table")
+@pytest.mark.usefixtures("_prepare_env", "_initial_setup_required", "linked_table")
 class TestCallWithInitialSetup:
     def test_if_configuration_of_outbound_table_cls_factory_is_correct(
         self, table_cls_factory_spies, basic_outbound_config, source_table_cls_stub

--- a/tests/unit/frameworks/datajoint/test_mixin.py
+++ b/tests/unit/frameworks/datajoint/test_mixin.py
@@ -50,7 +50,7 @@ def source_table_factory_spy():
 
 
 @pytest.fixture(autouse=True)
-def configure_mixin(fake_controller, fake_temp_dir, source_table_factory_spy, printer_spy):
+def _configure_mixin(fake_controller, fake_temp_dir, source_table_factory_spy, printer_spy):
     LocalTableMixin.controller = fake_controller
     LocalTableMixin.temp_dir = fake_temp_dir
     LocalTableMixin.source_table_factory = source_table_factory_spy

--- a/tests/unit/frameworks/datajoint/test_mixin.py
+++ b/tests/unit/frameworks/datajoint/test_mixin.py
@@ -8,7 +8,7 @@ from dj_link.frameworks.datajoint.mixin import LocalTableMixin
 from dj_link.use_cases import USE_CASES
 
 
-@pytest.fixture
+@pytest.fixture()
 def fake_controller():
     class FakeController:
         is_in_with_clause = False
@@ -25,7 +25,7 @@ def fake_controller():
     return fake_controller
 
 
-@pytest.fixture
+@pytest.fixture()
 def fake_temp_dir(fake_controller):
     class FakeTemporaryDirectory:
         controller = fake_controller
@@ -39,12 +39,12 @@ def fake_temp_dir(fake_controller):
     return FakeTemporaryDirectory()
 
 
-@pytest.fixture
+@pytest.fixture()
 def printer_spy():
     return MagicMock(name="printer_spy")
 
 
-@pytest.fixture
+@pytest.fixture()
 def source_table_factory_spy():
     return create_autospec(TableFactory, instance=True)()
 

--- a/tests/unit/frameworks/datajoint/test_printer.py
+++ b/tests/unit/frameworks/datajoint/test_printer.py
@@ -71,17 +71,17 @@ def data(request):
     return request.param
 
 
-@pytest.fixture
+@pytest.fixture()
 def message(data):
     return data[0]
 
 
-@pytest.fixture
+@pytest.fixture()
 def fields(data):
     return data[1]
 
 
-@pytest.fixture
+@pytest.fixture()
 def view_model_stub(message, fields):
     stub = create_autospec(ViewModel, instance=True)
     stub.message = message
@@ -89,12 +89,12 @@ def view_model_stub(message, fields):
     return stub
 
 
-@pytest.fixture
+@pytest.fixture()
 def printer(view_model_stub):
     return Printer(view_model_stub)
 
 
-@pytest.fixture
+@pytest.fixture()
 def expected(data):
     return "\n".join(data[2] + [""])
 

--- a/tests/unit/test_docker.py
+++ b/tests/unit/test_docker.py
@@ -102,13 +102,15 @@ def test_if_reload_method_of_container_is_called_correctly(container_spy, contai
 def test_if_container_is_stopped_if_not_healthy_after_max_retries(container_runner, container_spy):
     with pytest.raises(RuntimeError):
         with container_runner(health_check_config={"max_retries": 5, "interval": 0}):
-            container_spy.stop.assert_called_once_with()
+            pass
+    container_spy.stop.assert_called_once_with()
 
 
 def test_if_runtime_error_is_raised_if_not_healthy_after_max_retries(container_runner, container_spy):
     with pytest.raises(RuntimeError) as exc_info:
         with container_runner(health_check_config={"max_retries": 5, "interval": 0}):
-            assert exc_info.value.args[0] == "Container 'container' not healthy after max number (2) of retries"
+            pass
+    assert exc_info.value.args[0] == "Container 'container_spy' not healthy after max number (5) of retries"
 
 
 def test_if_container_is_returned(container_runner, container_spy):

--- a/tests/unit/test_docker.py
+++ b/tests/unit/test_docker.py
@@ -12,7 +12,7 @@ def test_if_subclass_of_abstract_context_manager():
     assert issubclass(ContainerRunner, AbstractContextManager)
 
 
-@pytest.fixture
+@pytest.fixture()
 def container_spy():
     container_spy = MagicMock(name="container_spy")
     container_spy.name = "container_spy"
@@ -30,7 +30,7 @@ def container_spy():
     return container_spy
 
 
-@pytest.fixture
+@pytest.fixture()
 def docker_client_spy(container_spy):
     client = MagicMock(name="docker_client_spy")
     client.containers.run.return_value = container_spy
@@ -38,12 +38,12 @@ def docker_client_spy(container_spy):
     return client
 
 
-@pytest.fixture
+@pytest.fixture()
 def container_config():
     return {"image": "my-image"}
 
 
-@pytest.fixture
+@pytest.fixture()
 def container_runner(docker_client_spy, container_config):
     return partial(ContainerRunner, docker_client_spy, container_config)
 

--- a/tests/unit/test_schemas.py
+++ b/tests/unit/test_schemas.py
@@ -14,34 +14,34 @@ def test_if_schema_cls_is_correct():
     assert schemas.LazySchema._schema_cls is Schema
 
 
-@pytest.fixture
+@pytest.fixture()
 def schema_name():
     return "schema_name"
 
 
-@pytest.fixture
+@pytest.fixture()
 def context():
     return dict()
 
 
-@pytest.fixture
+@pytest.fixture()
 def connection():
     return MagicMock(name="connection", spec=Connection)
 
 
-@pytest.fixture
+@pytest.fixture()
 def schema():
     return MagicMock(name="schema", spec=Schema, some_attribute="some_value")
 
 
-@pytest.fixture
+@pytest.fixture()
 def schema_cls(schema, connection):
     schema_cls = MagicMock(name="schema_cls", spec=Type[Schema], return_value=schema)
     schema_cls.return_value.connection = connection
     return schema_cls
 
 
-@pytest.fixture
+@pytest.fixture()
 def lazy_schema_cls(schema_cls):
     class LazySchema(schemas.LazySchema):
         pass
@@ -82,15 +82,15 @@ class TestInit:
 
 
 class TestInitialize:
-    @pytest.fixture
+    @pytest.fixture()
     def setup_env(self):
         os.environ.update(LINK_USER="user", LINK_PASS="pass")
 
-    @pytest.fixture
+    @pytest.fixture()
     def conn_cls(self, connection):
         return MagicMock(name="conn_cls", spec=Type[Connection], return_value=connection)
 
-    @pytest.fixture
+    @pytest.fixture()
     def lazy_schema_cls(self, lazy_schema_cls, conn_cls):
         lazy_schema_cls._conn_cls = conn_cls
         return lazy_schema_cls
@@ -131,7 +131,7 @@ class TestInitialize:
         assert schema_cls.call_count == 1
 
 
-@pytest.fixture
+@pytest.fixture()
 def lazy_schema(lazy_schema_cls, schema_name):
     return lazy_schema_cls(schema_name)
 
@@ -164,15 +164,15 @@ class TestGetAttr:
 
 
 class TestCall:
-    @pytest.fixture
+    @pytest.fixture()
     def table_cls(self):
         return MagicMock(name="table_cls", spec=Type[Table])
 
-    @pytest.fixture
+    @pytest.fixture()
     def processed_table_class(self):
         return MagicMock(name="processed_table_cls", spec=Type[Table])
 
-    @pytest.fixture
+    @pytest.fixture()
     def schema(self, schema, processed_table_class):
         schema.return_value = processed_table_class
         return schema

--- a/tests/unit/test_schemas.py
+++ b/tests/unit/test_schemas.py
@@ -53,7 +53,7 @@ def lazy_schema_cls(schema_cls):
 
 class TestInit:
     def test_if_value_error_is_raised_if_initialized_with_connection_and_host(self, connection):
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="Expected either"):
             schemas.LazySchema(schema_name, connection=connection, host="host")
 
     def test_if_schema_name_is_stored_as_instance_attribute(self, lazy_schema_cls, schema_name):

--- a/tests/unit/test_schemas.py
+++ b/tests/unit/test_schemas.py
@@ -83,7 +83,7 @@ class TestInit:
 
 class TestInitialize:
     @pytest.fixture()
-    def setup_env(self):
+    def _setup_env(self):
         os.environ.update(LINK_USER="user", LINK_PASS="pass")
 
     @pytest.fixture()
@@ -95,12 +95,12 @@ class TestInitialize:
         lazy_schema_cls._conn_cls = conn_cls
         return lazy_schema_cls
 
-    @pytest.mark.usefixtures("setup_env")
+    @pytest.mark.usefixtures("_setup_env")
     def test_if_connection_is_correctly_initialized_if_host_is_provided(self, lazy_schema_cls, schema_name, conn_cls):
         lazy_schema_cls(schema_name, host="host").initialize()
         conn_cls.assert_called_once_with("host", "user", "pass")
 
-    @pytest.mark.usefixtures("setup_env")
+    @pytest.mark.usefixtures("_setup_env")
     def test_if_initialized_connection_is_stored_as_instance_attribute_if_host_is_provided(
         self, lazy_schema_cls, schema_name, connection
     ):
@@ -108,7 +108,7 @@ class TestInitialize:
         lazy_schema.initialize()
         assert lazy_schema.connection is connection
 
-    @pytest.mark.usefixtures("setup_env")
+    @pytest.mark.usefixtures("_setup_env")
     def test_if_schema_is_correctly_initialized(self, lazy_schema_cls, schema_name, schema_cls):
         lazy_schema_cls(schema_name).initialize()
         schema_cls.assert_called_once_with(

--- a/tests/unit/use_cases/conftest.py
+++ b/tests/unit/use_cases/conftest.py
@@ -7,24 +7,24 @@ from dj_link.entities.flag_manager import FlagManager
 from dj_link.use_cases import REQUEST_MODELS, RESPONSE_MODELS, USE_CASES, RepositoryLink, RepositoryLinkFactory
 
 
-@pytest.fixture
+@pytest.fixture()
 def identifiers(create_identifiers):
     return create_identifiers(3)
 
 
-@pytest.fixture
+@pytest.fixture()
 def request_model_stub(request, identifiers):
     stub = create_autospec(REQUEST_MODELS[request.module.USE_CASE_NAME], instance=True)
     stub.identifiers = identifiers
     return stub
 
 
-@pytest.fixture
+@pytest.fixture()
 def response_model_cls_spy(request):
     return create_autospec(RESPONSE_MODELS[request.module.USE_CASE_NAME])
 
 
-@pytest.fixture
+@pytest.fixture()
 def use_case_cls(request, response_model_cls_spy):
     use_case_cls = type(
         USE_CASES[request.module.USE_CASE_NAME].__name__, (USE_CASES[request.module.USE_CASE_NAME],), dict()
@@ -33,29 +33,29 @@ def use_case_cls(request, response_model_cls_spy):
     return use_case_cls
 
 
-@pytest.fixture
+@pytest.fixture()
 def repo_link_spy():
     spy = create_autospec(RepositoryLink, instance=True)
     spy.mock_add_spec(["source", "outbound", "local"])
     return spy
 
 
-@pytest.fixture
+@pytest.fixture()
 def repo_link_factory_stub(repo_link_spy):
     return create_autospec(RepositoryLinkFactory, instance=True, return_value=repo_link_spy)
 
 
-@pytest.fixture
+@pytest.fixture()
 def output_port_spy():
     return MagicMock(name="output_port_spy")
 
 
-@pytest.fixture
+@pytest.fixture()
 def use_case(use_case_cls, fake_gateway_link, repo_link_factory_stub, output_port_spy):
     return use_case_cls(fake_gateway_link, repo_link_factory_stub, output_port_spy)
 
 
-@pytest.fixture
+@pytest.fixture()
 def create_flag_manager_spies():
     def _create_flag_manager_spies(identifiers, flags):
         spies = {}
@@ -68,7 +68,7 @@ def create_flag_manager_spies():
     return _create_flag_manager_spies
 
 
-@pytest.fixture
+@pytest.fixture()
 def is_correct_log(caplog):
     def _is_correct_log(logger, func, messages, log_level=logging.INFO):
         with caplog.at_level(log_level, logger=logger.name):

--- a/tests/unit/use_cases/response_models/conftest.py
+++ b/tests/unit/use_cases/response_models/conftest.py
@@ -1,6 +1,6 @@
 import pytest
 
 
-@pytest.fixture
+@pytest.fixture()
 def requested(create_identifiers):
     return set(create_identifiers(10))

--- a/tests/unit/use_cases/response_models/test_delete_response_model.py
+++ b/tests/unit/use_cases/response_models/test_delete_response_model.py
@@ -3,22 +3,22 @@ import pytest
 from dj_link.use_cases.delete import DeleteResponseModel
 
 
-@pytest.fixture
+@pytest.fixture()
 def deletion_approved(create_identifiers):
     return set(create_identifiers(5))
 
 
-@pytest.fixture
+@pytest.fixture()
 def deleted_from_outbound(create_identifiers):
     return set(create_identifiers(range(5, 10)))
 
 
-@pytest.fixture
+@pytest.fixture()
 def deleted_from_local(create_identifiers):
     return set(create_identifiers(10))
 
 
-@pytest.fixture
+@pytest.fixture()
 def model(requested, deletion_approved, deleted_from_outbound, deleted_from_local):
     return DeleteResponseModel(
         requested=requested,
@@ -29,7 +29,7 @@ def model(requested, deletion_approved, deleted_from_outbound, deleted_from_loca
 
 
 @pytest.mark.parametrize(
-    "name,length",
+    ("name", "length"),
     [("requested", 10), ("deletion_approved", 5), ("deleted_from_outbound", 5), ("deleted_from_local", 10)],
 )
 def test_n_property(model, name, length):

--- a/tests/unit/use_cases/response_models/test_pull_response_model.py
+++ b/tests/unit/use_cases/response_models/test_pull_response_model.py
@@ -3,21 +3,21 @@ import pytest
 from dj_link.use_cases.pull import PullResponseModel
 
 
-@pytest.fixture
+@pytest.fixture()
 def valid(create_identifiers):
     return set(create_identifiers(5))
 
 
-@pytest.fixture
+@pytest.fixture()
 def invalid(create_identifiers):
     return set(create_identifiers(range(5, 10)))
 
 
-@pytest.fixture
+@pytest.fixture()
 def model(requested, valid, invalid):
     return PullResponseModel(requested=requested, valid=valid, invalid=invalid)
 
 
-@pytest.mark.parametrize("name,length", [("requested", 10), ("valid", 5), ("invalid", 5)])
+@pytest.mark.parametrize(("name", "length"), [("requested", 10), ("valid", 5), ("invalid", 5)])
 def test_n_property(model, name, length):
     assert getattr(model, "n_" + name) == length

--- a/tests/unit/use_cases/response_models/test_refresh_response_model.py
+++ b/tests/unit/use_cases/response_models/test_refresh_response_model.py
@@ -3,12 +3,12 @@ import pytest
 from dj_link.use_cases.refresh import RefreshResponseModel
 
 
-@pytest.fixture
+@pytest.fixture()
 def refreshed(create_identifiers):
     return set(create_identifiers(10))
 
 
-@pytest.fixture
+@pytest.fixture()
 def model(refreshed):
     return RefreshResponseModel(refreshed=refreshed)
 

--- a/tests/unit/use_cases/test_all_use_cases.py
+++ b/tests/unit/use_cases/test_all_use_cases.py
@@ -9,7 +9,7 @@ def use_case_name(request):
     return request.param
 
 
-@pytest.fixture
+@pytest.fixture()
 def use_case_cls(use_case_name):
     return USE_CASES[use_case_name]
 
@@ -18,7 +18,7 @@ def test_if_subclass_of_use_case(use_case_cls):
     assert issubclass(use_case_cls, AbstractUseCase)
 
 
-@pytest.fixture
+@pytest.fixture()
 def response_model_cls(use_case_name):
     return RESPONSE_MODELS[use_case_name]
 

--- a/tests/unit/use_cases/test_delete_use_case.py
+++ b/tests/unit/use_cases/test_delete_use_case.py
@@ -9,17 +9,17 @@ from dj_link.use_cases.delete import LOGGER
 USE_CASE_NAME = "delete"
 
 
-@pytest.fixture
+@pytest.fixture()
 def deletion_requested():
     return [False, True, False]
 
 
-@pytest.fixture
+@pytest.fixture()
 def flag_manager_spies(create_flag_manager_spies, identifiers, deletion_requested):
     return create_flag_manager_spies(identifiers, deletion_requested)
 
 
-@pytest.fixture
+@pytest.fixture()
 def repo_link_spy(repo_link_spy, flag_manager_spies):
     repo_link_spy.outbound.flags = flag_manager_spies
     return repo_link_spy
@@ -39,7 +39,7 @@ def test_if_deletion_is_approved_on_entities_that_had_it_requested(
         spy.__setitem__.assert_called_once_with("deletion_approved", True)
 
 
-@pytest.fixture
+@pytest.fixture()
 def deletion_not_requested_identifiers(identifiers, deletion_requested):
     return compress(identifiers, [not f for f in deletion_requested])
 

--- a/tests/unit/use_cases/test_refresh_use_case.py
+++ b/tests/unit/use_cases/test_refresh_use_case.py
@@ -9,32 +9,32 @@ from dj_link.use_cases.refresh import LOGGER, RefreshRequestModel
 USE_CASE_NAME = "refresh"
 
 
-@pytest.fixture
+@pytest.fixture()
 def dummy_request_model():
     return create_autospec(RefreshRequestModel, instance=True)
 
 
-@pytest.fixture
+@pytest.fixture()
 def outbound_deletion_requested():
     return [True, False, True]
 
 
-@pytest.fixture
+@pytest.fixture()
 def outbound_flag_manager_spies(create_flag_manager_spies, identifiers, outbound_deletion_requested):
     return create_flag_manager_spies(identifiers, outbound_deletion_requested)
 
 
-@pytest.fixture
+@pytest.fixture()
 def local_deletion_requested():
     return [False, False, True]
 
 
-@pytest.fixture
+@pytest.fixture()
 def local_flag_manager_spies(create_flag_manager_spies, identifiers, local_deletion_requested):
     return create_flag_manager_spies(identifiers, local_deletion_requested)
 
 
-@pytest.fixture
+@pytest.fixture()
 def repo_link_spy(repo_link_spy, identifiers, outbound_flag_manager_spies, local_flag_manager_spies):
     repo_link_spy.outbound.__iter__.return_value = identifiers
     repo_link_spy.outbound.flags = outbound_flag_manager_spies
@@ -42,7 +42,7 @@ def repo_link_spy(repo_link_spy, identifiers, outbound_flag_manager_spies, local
     return repo_link_spy
 
 
-@pytest.fixture
+@pytest.fixture()
 def call(use_case, dummy_request_model):
     use_case(dummy_request_model)
 
@@ -61,7 +61,7 @@ def test_if_deletion_requested_flag_is_checked_on_local_entities_corresponding_t
         spy.__getitem__.assert_called_once_with("deletion_requested")
 
 
-@pytest.fixture
+@pytest.fixture()
 def to_be_enabled(outbound_deletion_requested, local_deletion_requested):
     return [b1 and not b2 for b1, b2 in zip(outbound_deletion_requested, local_deletion_requested)]
 

--- a/tests/unit/use_cases/test_refresh_use_case.py
+++ b/tests/unit/use_cases/test_refresh_use_case.py
@@ -43,17 +43,17 @@ def repo_link_spy(repo_link_spy, identifiers, outbound_flag_manager_spies, local
 
 
 @pytest.fixture()
-def call(use_case, dummy_request_model):
+def _call(use_case, dummy_request_model):
     use_case(dummy_request_model)
 
 
-@pytest.mark.usefixtures("call")
+@pytest.mark.usefixtures("_call")
 def test_if_deletion_requested_flag_is_checked_on_all_entities_in_outbound_repo(outbound_flag_manager_spies):
     for spy in outbound_flag_manager_spies.values():
         spy.__getitem__.assert_called_once_with("deletion_requested")
 
 
-@pytest.mark.usefixtures("call")
+@pytest.mark.usefixtures("_call")
 def test_if_deletion_requested_flag_is_checked_on_local_entities_corresponding_to_outbound_entities_that_had_it_enabled(
     outbound_deletion_requested, local_flag_manager_spies
 ):
@@ -66,13 +66,13 @@ def to_be_enabled(outbound_deletion_requested, local_deletion_requested):
     return [b1 and not b2 for b1, b2 in zip(outbound_deletion_requested, local_deletion_requested)]
 
 
-@pytest.mark.usefixtures("call")
+@pytest.mark.usefixtures("_call")
 def test_if_deletion_requested_flag_is_enabled_on_local_entities(to_be_enabled, local_flag_manager_spies):
     for spy in compress(local_flag_manager_spies.values(), to_be_enabled):
         spy.__setitem__.assert_called_once_with("deletion_requested", True)
 
 
-@pytest.mark.usefixtures("call")
+@pytest.mark.usefixtures("_call")
 def test_if_initialization_of_response_model_class_is_correct(response_model_cls_spy, identifiers, to_be_enabled):
     response_model_cls_spy.assert_called_once_with(set(compress(identifiers, to_be_enabled)))
 
@@ -85,6 +85,6 @@ def test_if_logged_messages_are_correct(use_case, dummy_request_model, is_correc
     assert is_correct_log(LOGGER, partial(use_case, dummy_request_model), messages)
 
 
-@pytest.mark.usefixtures("call")
+@pytest.mark.usefixtures("_call")
 def test_if_response_model_is_passed_to_output_port(response_model_cls_spy, output_port_spy):
     output_port_spy.assert_called_once_with(response_model_cls_spy.return_value)

--- a/tests/unit/use_cases/test_use_cases_init.py
+++ b/tests/unit/use_cases/test_use_cases_init.py
@@ -9,29 +9,29 @@ from dj_link.entities.repository import RepositoryFactory
 from dj_link.use_cases.gateway import GatewayLink
 
 
-@pytest.fixture
+@pytest.fixture()
 def kinds():
     return "source", "outbound", "local"
 
 
-@pytest.fixture
+@pytest.fixture()
 def repos(kinds):
     return {kind: MagicMock(name=kind + "_repo") for kind in kinds}
 
 
-@pytest.fixture
+@pytest.fixture()
 def repo_factory_cls_spy(repos):
     repo_factory_cls_spy = MagicMock(name="repo_factory_cls_spy", spec=Type[RepositoryFactory])
     repo_factory_cls_spy.return_value.side_effect = repos.values()
     return repo_factory_cls_spy
 
 
-@pytest.fixture
+@pytest.fixture()
 def gateway_link_stub():
     return MagicMock(name="gateway_link_stub", spec=GatewayLink)
 
 
-@pytest.fixture
+@pytest.fixture()
 def factory(repo_factory_cls_spy, gateway_link_stub):
     class RepositoryLinkFactory(use_cases.RepositoryLinkFactory):
         repo_factory_cls = repo_factory_cls_spy
@@ -73,7 +73,7 @@ class TestRepositoryLinkFactory:
 
 
 class TestInitializeUseCases:
-    @pytest.fixture
+    @pytest.fixture()
     def dummy_output_ports(self):
         return {n: MagicMock(name="dummy_" + n + "_output_port") for n in use_cases.USE_CASES}
 
@@ -81,15 +81,15 @@ class TestInitializeUseCases:
     def use_case_name(self, request):
         return request.param
 
-    @pytest.fixture
+    @pytest.fixture()
     def dummy_output_port(self, use_case_name, dummy_output_ports):
         return dummy_output_ports[use_case_name]
 
-    @pytest.fixture
+    @pytest.fixture()
     def use_case(self, gateway_link_stub, dummy_output_ports, use_case_name):
         return use_cases.initialize_use_cases(gateway_link_stub, dummy_output_ports)[use_case_name]
 
-    @pytest.fixture
+    @pytest.fixture()
     def use_case_cls(self, use_case_name):
         return use_cases.USE_CASES[use_case_name]
 


### PR DESCRIPTION
- Improve code style related to pytest
- Simplify pytest.raises blocks to single statement
- Use more precise check with pytest.raises
- Add leading underscore to fixtures returning none
- Break down assertion into multiple parts
- Enable ruff rules regarding pytest
