### PR TITLE
Restrict source endpoint to idle entities

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,19 +72,19 @@ class Table:
 
 Note that the name of the declared class must match the name of the table from which the data will be pulled.
 
-The class returned by the decorator behaves like a regular table with some added functionality. For one it allows the browsing of data present in the source table:
+The class returned by the decorator behaves like a regular table with some added functionality. For one it allows the browsing of rows that can be pulled from the source:
 
 ```python
 Table().source
 ```
 
-All the data can be pulled like so:
+All the rows can be pulled like so:
 
 ```python
 Table().source.pull()
 ```
 
-That said usually we only want to pull some rows that match a certain criteria:
+That said usually we only want to pull rows that match a certain criteria:
 
 ```python
 (Table().source & "foo = 1").pull()

--- a/dj_link/adapters/controller.py
+++ b/dj_link/adapters/controller.py
@@ -5,6 +5,7 @@ from typing import Callable, Iterable, Mapping
 
 from dj_link.use_cases.use_cases import (
     DeleteRequestModel,
+    ListIdleEntitiesRequestModel,
     ProcessRequestModel,
     PullRequestModel,
     RequestModel,
@@ -40,3 +41,7 @@ class DJController:
         self.__handlers[UseCases.PROCESS](
             ProcessRequestModel(frozenset(self.__translator.to_identifiers(primary_keys)))
         )
+
+    def list_idle_entities(self) -> None:
+        """Execute the use-case that lists idle entities."""
+        self.__handlers[UseCases.LISTIDLEENTITIES](ListIdleEntitiesRequestModel())

--- a/dj_link/adapters/controller.py
+++ b/dj_link/adapters/controller.py
@@ -3,8 +3,13 @@ from __future__ import annotations
 
 from typing import Callable, Iterable, Mapping
 
-from dj_link.entities.custom_types import Identifier
-from dj_link.use_cases.use_cases import UseCases
+from dj_link.use_cases.use_cases import (
+    DeleteRequestModel,
+    ProcessRequestModel,
+    PullRequestModel,
+    RequestModel,
+    UseCases,
+)
 
 from .custom_types import PrimaryKey
 from .identification import IdentificationTranslator
@@ -15,7 +20,7 @@ class DJController:
 
     def __init__(
         self,
-        handlers: Mapping[UseCases, Callable[[Iterable[Identifier]], None]],
+        handlers: Mapping[UseCases, Callable[[RequestModel], None]],
         translator: IdentificationTranslator,
     ) -> None:
         """Initialize the translator."""
@@ -24,12 +29,14 @@ class DJController:
 
     def pull(self, primary_keys: Iterable[PrimaryKey]) -> None:
         """Execute the pull use-case."""
-        self.__handlers[UseCases.PULL](self.__translator.to_identifiers(primary_keys))
+        self.__handlers[UseCases.PULL](PullRequestModel(frozenset(self.__translator.to_identifiers(primary_keys))))
 
     def delete(self, primary_keys: Iterable[PrimaryKey]) -> None:
         """Execute the delete use-case."""
-        self.__handlers[UseCases.DELETE](self.__translator.to_identifiers(primary_keys))
+        self.__handlers[UseCases.DELETE](DeleteRequestModel(frozenset(self.__translator.to_identifiers(primary_keys))))
 
     def process(self, primary_keys: Iterable[PrimaryKey]) -> None:
         """Execute the process use-case."""
-        self.__handlers[UseCases.PROCESS](self.__translator.to_identifiers(primary_keys))
+        self.__handlers[UseCases.PROCESS](
+            ProcessRequestModel(frozenset(self.__translator.to_identifiers(primary_keys)))
+        )

--- a/dj_link/adapters/presenter.py
+++ b/dj_link/adapters/presenter.py
@@ -1,10 +1,30 @@
 """Contains the presenter class and related classes/functions."""
 
-from dj_link.use_cases.use_cases import DeleteResponseModel, ProcessResponseModel, PullResponseModel
+from typing import Callable, Iterable
+
+from dj_link.use_cases.use_cases import (
+    DeleteResponseModel,
+    ListIdleEntitiesResponseModel,
+    ProcessResponseModel,
+    PullResponseModel,
+)
+
+from .custom_types import PrimaryKey
+from .identification import IdentificationTranslator
 
 
 class DJPresenter:
     """DataJoint-specific presenter."""
+
+    def __init__(
+        self,
+        translator: IdentificationTranslator,
+        *,
+        update_idle_entities_list: Callable[[Iterable[PrimaryKey]], None],
+    ) -> None:
+        """Initialize the presenter."""
+        self._translator = translator
+        self._update_idle_entities_list = update_idle_entities_list
 
     def pull(self, response: PullResponseModel) -> None:
         """Present information about a finished pull use-case."""
@@ -14,3 +34,9 @@ class DJPresenter:
 
     def process(self, response: ProcessResponseModel) -> None:
         """Present information about a finished process use-case."""
+
+    def update_idle_entities_list(self, response: ListIdleEntitiesResponseModel) -> None:
+        """Update the list of idle entities."""
+        self._update_idle_entities_list(
+            self._translator.to_primary_key(identifier) for identifier in response.identifiers
+        )

--- a/dj_link/entities/link.py
+++ b/dj_link/entities/link.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, FrozenSet, Iterable, Mapping, Optional, TypeVar
+from typing import Any, FrozenSet, Iterable, Iterator, Mapping, Optional, TypeVar
 
 from .custom_types import Identifier
 from .state import (
@@ -110,6 +110,10 @@ class Link:
             Components.LOCAL: self.local,
         }
         return component_map[component]
+
+    def __iter__(self) -> Iterator[Entity]:
+        """Iterate over all entities in the link."""
+        return iter(self.source)
 
 
 class Component(FrozenSet[Entity]):

--- a/dj_link/frameworks/sequence.py
+++ b/dj_link/frameworks/sequence.py
@@ -1,0 +1,45 @@
+"""Contains sequence related functionality."""
+from __future__ import annotations
+
+import collections
+from collections.abc import MutableSequence
+from typing import TYPE_CHECKING, Callable, Iterable, Iterator, TypeVar
+
+if TYPE_CHECKING:
+    UserList = collections.UserList
+else:
+
+    class _UserList:
+        def __getitem__(*args):
+            return collections.UserList
+
+    UserList = _UserList()
+_T = TypeVar("_T")
+
+
+class IterationCallbackList(UserList[_T]):
+    """A list that invokes a callback whenever it gets iterated over."""
+
+    def __init__(self, data: Iterable[_T] | None = None) -> None:
+        """Initialize the list."""
+        super().__init__(data)
+        self.callback: Callable[[], None] | None = None
+
+    def __iter__(self) -> Iterator[_T]:
+        """Iterate over the list."""
+        if self.callback is not None:
+            self.callback()
+        return super().__iter__()
+
+
+_V = TypeVar("_V")
+
+
+def create_content_replacer(sequence: MutableSequence[_V]) -> Callable[[Iterable[_V]], None]:
+    """Create a callable that replaces the sequence's contents in-place when called."""
+
+    def replace_contents(new: Iterable[_V]) -> None:
+        sequence.clear()
+        sequence.extend(new)
+
+    return replace_contents

--- a/dj_link/use_cases/use_cases.py
+++ b/dj_link/use_cases/use_cases.py
@@ -19,14 +19,28 @@ class ResponseModel:
 
 
 @dataclass(frozen=True)
+class PullRequestModel:
+    """Request model for the pull use-case."""
+
+    requested: frozenset[Identifier]
+
+
+@dataclass(frozen=True)
 class PullResponseModel(ResponseModel):
     """Response model for the pull use-case."""
 
 
 def pull(
-    requested: Iterable[Identifier], *, link_gateway: LinkGateway, output_port: Callable[[PullResponseModel], None]
+    request: Iterable[Identifier] | PullRequestModel,
+    *,
+    link_gateway: LinkGateway,
+    output_port: Callable[[PullResponseModel], None],
 ) -> None:
     """Pull entities across the link."""
+    if isinstance(request, PullRequestModel):
+        requested = request.requested
+    else:
+        requested = frozenset(request)
     result = pull_domain_service(link_gateway.create_link(), requested=requested)
     link_gateway.apply(result.updates)
     output_port(PullResponseModel())

--- a/dj_link/use_cases/use_cases.py
+++ b/dj_link/use_cases/use_cases.py
@@ -14,12 +14,16 @@ from dj_link.entities.link import pull as pull_domain_service
 from .gateway import LinkGateway
 
 
+class RequestModel:
+    """Base class for all request models."""
+
+
 class ResponseModel:
     """Base class for all response models."""
 
 
 @dataclass(frozen=True)
-class PullRequestModel:
+class PullRequestModel(RequestModel):
     """Request model for the pull use-case."""
 
     requested: frozenset[Identifier]
@@ -47,7 +51,7 @@ def pull(
 
 
 @dataclass(frozen=True)
-class DeleteRequestModel:
+class DeleteRequestModel(RequestModel):
     """Request model for the delete use-case."""
 
     requested: frozenset[Identifier]
@@ -75,7 +79,7 @@ def delete(
 
 
 @dataclass(frozen=True)
-class ProcessRequestModel:
+class ProcessRequestModel(RequestModel):
     """Request model for the process use-case."""
 
     requested: frozenset[Identifier]

--- a/dj_link/use_cases/use_cases.py
+++ b/dj_link/use_cases/use_cases.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 from collections.abc import Callable
 from dataclasses import dataclass
 from enum import Enum, auto
-from typing import Iterable
 
 from dj_link.entities.custom_types import Identifier
 from dj_link.entities.link import delete as delete_domain_service
@@ -35,17 +34,10 @@ class PullResponseModel(ResponseModel):
 
 
 def pull(
-    request: Iterable[Identifier] | PullRequestModel,
-    *,
-    link_gateway: LinkGateway,
-    output_port: Callable[[PullResponseModel], None],
+    request: PullRequestModel, *, link_gateway: LinkGateway, output_port: Callable[[PullResponseModel], None]
 ) -> None:
     """Pull entities across the link."""
-    if isinstance(request, PullRequestModel):
-        requested = request.requested
-    else:
-        requested = frozenset(request)
-    result = pull_domain_service(link_gateway.create_link(), requested=requested)
+    result = pull_domain_service(link_gateway.create_link(), requested=request.requested)
     link_gateway.apply(result.updates)
     output_port(PullResponseModel())
 
@@ -63,17 +55,10 @@ class DeleteResponseModel(ResponseModel):
 
 
 def delete(
-    request: Iterable[Identifier] | DeleteRequestModel,
-    *,
-    link_gateway: LinkGateway,
-    output_port: Callable[[DeleteResponseModel], None],
+    request: DeleteRequestModel, *, link_gateway: LinkGateway, output_port: Callable[[DeleteResponseModel], None]
 ) -> None:
     """Delete pulled entities."""
-    if isinstance(request, DeleteRequestModel):
-        requested = request.requested
-    else:
-        requested = frozenset(request)
-    result = delete_domain_service(link_gateway.create_link(), requested=requested)
+    result = delete_domain_service(link_gateway.create_link(), requested=request.requested)
     link_gateway.apply(result.updates)
     output_port(DeleteResponseModel())
 
@@ -91,17 +76,10 @@ class ProcessResponseModel(ResponseModel):
 
 
 def process(
-    request: Iterable[Identifier] | ProcessRequestModel,
-    *,
-    link_gateway: LinkGateway,
-    output_port: Callable[[ProcessResponseModel], None],
+    request: ProcessRequestModel, *, link_gateway: LinkGateway, output_port: Callable[[ProcessResponseModel], None]
 ) -> None:
     """Process entities."""
-    if isinstance(request, ProcessRequestModel):
-        requested = request.requested
-    else:
-        requested = frozenset(request)
-    result = process_domain_service(link_gateway.create_link(), requested=requested)
+    result = process_domain_service(link_gateway.create_link(), requested=request.requested)
     link_gateway.apply(result.updates)
     output_port(ProcessResponseModel())
 

--- a/dj_link/use_cases/use_cases.py
+++ b/dj_link/use_cases/use_cases.py
@@ -47,17 +47,38 @@ def pull(
 
 
 @dataclass(frozen=True)
+class DeleteRequestModel:
+    """Request model for the delete use-case."""
+
+    requested: frozenset[Identifier]
+
+
+@dataclass(frozen=True)
 class DeleteResponseModel(ResponseModel):
     """Response model for the delete use-case."""
 
 
 def delete(
-    requested: Iterable[Identifier], *, link_gateway: LinkGateway, output_port: Callable[[DeleteResponseModel], None]
+    request: Iterable[Identifier] | DeleteRequestModel,
+    *,
+    link_gateway: LinkGateway,
+    output_port: Callable[[DeleteResponseModel], None],
 ) -> None:
     """Delete pulled entities."""
+    if isinstance(request, DeleteRequestModel):
+        requested = request.requested
+    else:
+        requested = frozenset(request)
     result = delete_domain_service(link_gateway.create_link(), requested=requested)
     link_gateway.apply(result.updates)
     output_port(DeleteResponseModel())
+
+
+@dataclass(frozen=True)
+class ProcessRequestModel:
+    """Request model for the process use-case."""
+
+    requested: frozenset[Identifier]
 
 
 @dataclass(frozen=True)
@@ -66,9 +87,16 @@ class ProcessResponseModel(ResponseModel):
 
 
 def process(
-    requested: Iterable[Identifier], *, link_gateway: LinkGateway, output_port: Callable[[ProcessResponseModel], None]
+    request: Iterable[Identifier] | ProcessRequestModel,
+    *,
+    link_gateway: LinkGateway,
+    output_port: Callable[[ProcessResponseModel], None],
 ) -> None:
     """Process entities."""
+    if isinstance(request, ProcessRequestModel):
+        requested = request.requested
+    else:
+        requested = frozenset(request)
     result = process_domain_service(link_gateway.create_link(), requested=requested)
     link_gateway.apply(result.updates)
     output_port(ProcessResponseModel())

--- a/dj_link/use_cases/use_cases.py
+++ b/dj_link/use_cases/use_cases.py
@@ -9,6 +9,7 @@ from dj_link.entities.custom_types import Identifier
 from dj_link.entities.link import delete as delete_domain_service
 from dj_link.entities.link import process as process_domain_service
 from dj_link.entities.link import pull as pull_domain_service
+from dj_link.entities.state import states
 
 from .gateway import LinkGateway
 
@@ -84,9 +85,36 @@ def process(
     output_port(ProcessResponseModel())
 
 
+@dataclass(frozen=True)
+class ListIdleEntitiesRequestModel(RequestModel):
+    """Request model for the use-case that lists idle entities."""
+
+
+@dataclass(frozen=True)
+class ListIdleEntitiesResponseModel(ResponseModel):
+    """Response model for the use-case that lists idle entities."""
+
+    identifiers: frozenset[Identifier]
+
+
+def list_idle_entities(
+    request: ListIdleEntitiesRequestModel,
+    *,
+    link_gateway: LinkGateway,
+    output_port: Callable[[ListIdleEntitiesResponseModel], None],
+) -> None:
+    """List all idle entities."""
+    output_port(
+        ListIdleEntitiesResponseModel(
+            frozenset(entity.identifier for entity in link_gateway.create_link() if entity.state is states.Idle)
+        )
+    )
+
+
 class UseCases(Enum):
     """Names for all available use-cases."""
 
     PULL = auto()
     DELETE = auto()
     PROCESS = auto()
+    LISTIDLEENTITIES = auto()

--- a/tests/functional/test_pulling.py
+++ b/tests/functional/test_pulling.py
@@ -93,3 +93,4 @@ def test_pulling(
                 actual = getattr(local_table_cls(), part_table_name).fetch(as_dict=True, download_path=tmpdir)
                 assert len(actual) == len(part_table_expected)
                 assert all(entry in part_table_expected for entry in actual)
+            assert local_table_cls().source.proj().fetch(as_dict=True) == [{"foo": 3}]

--- a/tests/integration/test_use_cases.py
+++ b/tests/integration/test_use_cases.py
@@ -9,7 +9,9 @@ from dj_link.entities.link import Link, create_link
 from dj_link.entities.state import Commands, Components, Processes, Update
 from dj_link.use_cases.gateway import LinkGateway
 from dj_link.use_cases.use_cases import (
+    DeleteRequestModel,
     DeleteResponseModel,
+    ProcessRequestModel,
     ProcessResponseModel,
     PullRequestModel,
     PullResponseModel,
@@ -122,7 +124,7 @@ def test_delete_process_is_started_when_pulled_entity_is_deleted() -> None:
         create_assignments({Components.SOURCE: {"1"}, Components.OUTBOUND: {"1"}, Components.LOCAL: {"1"}})
     )
     delete(
-        create_identifiers("1"),
+        DeleteRequestModel(frozenset(create_identifiers("1"))),
         link_gateway=gateway,
         output_port=FakeOutputPort[DeleteResponseModel](),
     )
@@ -139,7 +141,7 @@ def test_correct_response_model_gets_passed_to_delete_output_port() -> None:
     )
     output_port = FakeOutputPort[DeleteResponseModel]()
     delete(
-        create_identifiers("1"),
+        DeleteRequestModel(frozenset(create_identifiers("1"))),
         link_gateway=gateway,
         output_port=output_port,
     )
@@ -151,7 +153,11 @@ def test_entity_undergoing_process_gets_processed() -> None:
         create_assignments({Components.SOURCE: {"1"}, Components.OUTBOUND: {"1"}}),
         processes={Processes.PULL: create_identifiers("1")},
     )
-    process(create_identifiers("1"), link_gateway=gateway, output_port=FakeOutputPort[ProcessResponseModel]())
+    process(
+        ProcessRequestModel(frozenset(create_identifiers("1"))),
+        link_gateway=gateway,
+        output_port=FakeOutputPort[ProcessResponseModel](),
+    )
     assert has_state(
         gateway.create_link(),
         create_assignments({Components.SOURCE: {"1"}, Components.OUTBOUND: {"1"}, Components.LOCAL: {"1"}}),
@@ -164,5 +170,9 @@ def test_correct_response_model_gets_passed_to_process_output_port() -> None:
         processes={Processes.PULL: create_identifiers("1")},
     )
     output_port = FakeOutputPort[ProcessResponseModel]()
-    process(create_identifiers("1"), link_gateway=gateway, output_port=output_port)
+    process(
+        ProcessRequestModel(frozenset(create_identifiers("1"))),
+        link_gateway=gateway,
+        output_port=output_port,
+    )
     assert isinstance(output_port.response, ProcessResponseModel)

--- a/tests/integration/test_use_cases.py
+++ b/tests/integration/test_use_cases.py
@@ -11,6 +11,7 @@ from dj_link.use_cases.gateway import LinkGateway
 from dj_link.use_cases.use_cases import (
     DeleteResponseModel,
     ProcessResponseModel,
+    PullRequestModel,
     PullResponseModel,
     ResponseModel,
     delete,
@@ -94,7 +95,7 @@ class FakeOutputPort(Generic[T]):
 def test_pull_process_gets_started_when_idle_entity_gets_pulled() -> None:
     gateway = FakeLinkGateway(create_assignments({Components.SOURCE: {"1"}}))
     pull(
-        create_identifiers("1"),
+        PullRequestModel(frozenset(create_identifiers("1"))),
         link_gateway=gateway,
         output_port=FakeOutputPort[PullResponseModel](),
     )
@@ -109,7 +110,7 @@ def test_correct_response_model_gets_passed_to_pull_output_port() -> None:
     gateway = FakeLinkGateway(create_assignments({Components.SOURCE: {"1"}}))
     output_port = FakeOutputPort[PullResponseModel]()
     pull(
-        create_identifiers("1"),
+        PullRequestModel(frozenset(create_identifiers("1"))),
         link_gateway=gateway,
         output_port=output_port,
     )


### PR DESCRIPTION
Previously the source endpoint was unrestricted showing even entities that could not be pulled (e.g. because they already were pulled). With this PR the source endpoint is restricted to idle entities only.
