### PR TITLE
Fix `CURRENT_TIMESTAMP` breaking local table creation on mariadb

### DIFF
--- a/link/infrastructure/config.py
+++ b/link/infrastructure/config.py
@@ -41,6 +41,6 @@ def create_table_definition_provider(table: Callable[[], dj.Table]) -> Callable[
     """Create an object that provides the definition of the table produced by the given factory when called."""
 
     def provide_definition() -> str:
-        return str(table().heading)
+        return str(table().heading).replace('"current_timestamp()"', "CURRENT_TIMESTAMP")
 
     return provide_definition

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -20,7 +20,7 @@ from tests.docker.runner import ContainerRunner
 
 SCOPE = os.environ.get("SCOPE", "session")
 REMOVE = True
-DATABASE_IMAGE = "datajoint/mysql:latest"
+DATABASE_IMAGE = "cblessing24/mariadb:11.1"
 MINIO_IMAGE = "minio/minio:latest"
 DATABASE_ROOT_PASSWORD = "root"
 

--- a/tests/functional/test_creation.py
+++ b/tests/functional/test_creation.py
@@ -1,4 +1,5 @@
 import datajoint as dj
+import pytest
 
 from link import link
 
@@ -18,6 +19,26 @@ def test_local_table_creation_from_source_table_that_has_parent_raises_no_error(
         source_table,
         context={"source_table_parent": source_table_parent},
     )
+    with connection_config(databases["local"], user_specs["local"]), configured_environment(
+        user_specs["link"], schema_names["outbound"]
+    ):
+        link(
+            databases["source"].container.name,
+            schema_names["source"],
+            schema_names["outbound"],
+            "Outbound",
+            schema_names["local"],
+        )(type(source_table_name, (dj.Manual,), {}))
+
+
+@pytest.mark.xfail()
+def test_local_table_creation_from_source_table_that_uses_current_timestamp_default_raises_no_error(
+    prepare_link, create_table, prepare_table, databases, configured_environment, connection_config
+):
+    schema_names, user_specs = prepare_link()
+    source_table_name = "Foo"
+    source_table = create_table(source_table_name, dj.Manual, "foo = CURRENT_TIMESTAMP : timestamp")
+    prepare_table(databases["source"], user_specs["source"], schema_names["source"], source_table)
     with connection_config(databases["local"], user_specs["local"]), configured_environment(
         user_specs["link"], schema_names["outbound"]
     ):

--- a/tests/functional/test_creation.py
+++ b/tests/functional/test_creation.py
@@ -1,5 +1,4 @@
 import datajoint as dj
-import pytest
 
 from link import link
 
@@ -31,7 +30,6 @@ def test_local_table_creation_from_source_table_that_has_parent_raises_no_error(
         )(type(source_table_name, (dj.Manual,), {}))
 
 
-@pytest.mark.xfail()
 def test_local_table_creation_from_source_table_that_uses_current_timestamp_default_raises_no_error(
     prepare_link, create_table, prepare_table, databases, configured_environment, connection_config
 ):


### PR DESCRIPTION
- Run tests using mariadb instead of mysql
- Test local table creation with CURRENT_TIMESTAMP
- Fix CURRENT_TIMESTAMP breaking table creation
