### PR TITLE
Add unit of work

### DIFF
--- a/link/domain/link.py
+++ b/link/domain/link.py
@@ -70,8 +70,9 @@ def create_link(
             return Entity(
                 identifier,
                 state=state,
-                current_process=processes_map.get(identifier),
+                current_process=processes_map.get(identifier, Processes.NONE),
                 is_tainted=is_tainted(identifier),
+                operation_results=tuple(),
             )
 
         return {create_entity(identifier) for identifier in assignments[Components.SOURCE]}

--- a/link/domain/link.py
+++ b/link/domain/link.py
@@ -111,7 +111,7 @@ class Link(Set[Entity]):
         """Return the results of operations performed on this link."""
         return self._operation_results
 
-    def apply(self, operation: Operations, *, requested: Iterable[Identifier]) -> LinkOperationResult:
+    def apply(self, operation: Operations, *, requested: Iterable[Identifier]) -> Link:
         """Apply an operation to the requested entities."""
 
         def create_operation_result(results: Iterable[EntityOperationResult]) -> LinkOperationResult:
@@ -126,9 +126,12 @@ class Link(Set[Entity]):
 
         assert requested, "No identifiers requested."
         assert set(requested) <= self.identifiers, "Requested identifiers not present in link."
-        return create_operation_result(
-            entity.apply(operation).operation_results[0] for entity in self if entity.identifier in requested
+        changed = {entity.apply(operation) for entity in self if entity.identifier in requested}
+        unchanged = {entity for entity in self if entity.identifier not in requested}
+        operation_results = self.operation_results + (
+            create_operation_result(entity.operation_results[0] for entity in changed),
         )
+        return Link(changed | unchanged, operation_results)
 
     def __contains__(self, entity: object) -> bool:
         """Check if the link contains the given entity."""

--- a/link/domain/link.py
+++ b/link/domain/link.py
@@ -129,7 +129,7 @@ class Link(Set[Entity]):
         changed = {entity.apply(operation) for entity in self if entity.identifier in requested}
         unchanged = {entity for entity in self if entity.identifier not in requested}
         operation_results = self.operation_results + (
-            create_operation_result(entity.operation_results[0] for entity in changed),
+            create_operation_result(entity.operation_results[-1] for entity in changed),
         )
         return Link(changed | unchanged, operation_results)
 

--- a/link/domain/link.py
+++ b/link/domain/link.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Iterable, Iterator, Mapping, Optional, Set, TypeVar
+from typing import Any, Iterable, Iterator, Mapping, Optional, Set, Tuple, TypeVar
 
 from .custom_types import Identifier
 from .state import (
@@ -94,14 +94,22 @@ def create_link(
 class Link(Set[Entity]):
     """The state of a link between two databases."""
 
-    def __init__(self, entities: Iterable[Entity]) -> None:
+    def __init__(
+        self, entities: Iterable[Entity], operation_results: Tuple[LinkOperationResult, ...] = tuple()
+    ) -> None:
         """Initialize the link."""
         self._entities = set(entities)
+        self._operation_results = operation_results
 
     @property
     def identifiers(self) -> frozenset[Identifier]:
         """Return the identifiers of all entities in the link."""
         return frozenset(entity.identifier for entity in self)
+
+    @property
+    def operation_results(self) -> Tuple[LinkOperationResult, ...]:
+        """Return the results of operations performed on this link."""
+        return self._operation_results
 
     def apply(self, operation: Operations, *, requested: Iterable[Identifier]) -> LinkOperationResult:
         """Apply an operation to the requested entities."""

--- a/link/domain/link.py
+++ b/link/domain/link.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, FrozenSet, Iterable, Mapping, Optional, TypeVar
+from typing import Any, Iterable, Iterator, Mapping, Optional, Set, TypeVar
 
 from .custom_types import Identifier
 from .state import (
@@ -91,8 +91,12 @@ def create_link(
     return Link(entity_assignments[Components.SOURCE])
 
 
-class Link(FrozenSet[Entity]):
+class Link(Set[Entity]):
     """The state of a link between two databases."""
+
+    def __init__(self, entities: Iterable[Entity]) -> None:
+        """Initialize the link."""
+        self._entities = set(entities)
 
     @property
     def identifiers(self) -> frozenset[Identifier]:
@@ -136,6 +140,18 @@ class Link(FrozenSet[Entity]):
     def _validate_requested(self, requested: Iterable[Identifier]) -> None:
         assert requested, "No identifiers requested."
         assert set(requested) <= self.identifiers, "Requested identifiers not present in link."
+
+    def __contains__(self, entity: object) -> bool:
+        """Check if the link contains the given entity."""
+        return entity in self._entities
+
+    def __iter__(self) -> Iterator[Entity]:
+        """Iterate over all entities in the link."""
+        return iter(self._entities)
+
+    def __len__(self) -> int:
+        """Return the number of entities in the link."""
+        return len(self._entities)
 
 
 @dataclass(frozen=True)

--- a/link/domain/link.py
+++ b/link/domain/link.py
@@ -141,12 +141,7 @@ def _validate_requested(link: Link, requested: Iterable[Identifier]) -> None:
 
 
 def _create_update(current: Entity, operation: Operations) -> EntityOperationResult:
-    operations_map = {
-        Operations.START_PULL: "start_pull",
-        Operations.START_DELETE: "start_delete",
-        Operations.PROCESS: "process",
-    }
-    new = getattr(current, operations_map[operation])()
+    new = current.apply(operation)
     if current.state is new.state:
         return InvalidOperation(operation, current.identifier, current.state)
     transition = Transition(current.state, new.state)

--- a/link/domain/state.py
+++ b/link/domain/state.py
@@ -270,14 +270,23 @@ class Entity:
     current_process: Optional[Processes]
     is_tainted: bool
 
-    def start_pull(self) -> Entity:
+    def apply(self, operation: Operations) -> Entity:
+        """Apply an operation to the entity."""
+        if operation is Operations.START_PULL:
+            return self._start_pull()
+        if operation is Operations.START_DELETE:
+            return self._start_delete()
+        if operation is Operations.PROCESS:
+            return self._process()
+
+    def _start_pull(self) -> Entity:
         """Start the pull process for the entity."""
         return self.state.start_pull(self)
 
-    def start_delete(self) -> Entity:
+    def _start_delete(self) -> Entity:
         """Start the delete process for the entity."""
         return self.state.start_delete(self)
 
-    def process(self) -> Entity:
+    def _process(self) -> Entity:
         """Process the entity."""
         return self.state.process(self)

--- a/link/service/services.py
+++ b/link/service/services.py
@@ -127,7 +127,7 @@ def start_pull_process(
     output_port: Callable[[OperationResponse], None],
 ) -> None:
     """Start the pull process for the requested entities."""
-    result = link_gateway.create_link().apply(Operations.START_PULL, requested=request.requested)
+    result = link_gateway.create_link().apply(Operations.START_PULL, requested=request.requested).operation_results[0]
     link_gateway.apply(result.updates)
     output_port(OperationResponse(result.operation, request.requested, result.updates, result.errors))
 
@@ -146,7 +146,7 @@ def start_delete_process(
     output_port: Callable[[OperationResponse], None],
 ) -> None:
     """Start the delete process for the requested entities."""
-    result = link_gateway.create_link().apply(Operations.START_DELETE, requested=request.requested)
+    result = link_gateway.create_link().apply(Operations.START_DELETE, requested=request.requested).operation_results[0]
     link_gateway.apply(result.updates)
     output_port(OperationResponse(result.operation, request.requested, result.updates, result.errors))
 
@@ -162,7 +162,7 @@ def process(
     request: ProcessRequest, *, link_gateway: LinkGateway, output_port: Callable[[OperationResponse], None]
 ) -> None:
     """Process entities."""
-    result = link_gateway.create_link().apply(Operations.PROCESS, requested=request.requested)
+    result = link_gateway.create_link().apply(Operations.PROCESS, requested=request.requested).operation_results[0]
     link_gateway.apply(result.updates)
     output_port(OperationResponse(result.operation, request.requested, result.updates, result.errors))
 

--- a/link/service/services.py
+++ b/link/service/services.py
@@ -6,8 +6,6 @@ from dataclasses import dataclass
 from enum import Enum, auto
 
 from link.domain.custom_types import Identifier
-from link.domain.link import process as process_domain_service
-from link.domain.link import start_delete, start_pull
 from link.domain.state import InvalidOperation, Operations, Update, states
 
 from .gateway import LinkGateway
@@ -129,7 +127,7 @@ def start_pull_process(
     output_port: Callable[[OperationResponse], None],
 ) -> None:
     """Start the pull process for the requested entities."""
-    result = start_pull(link_gateway.create_link(), requested=request.requested)
+    result = link_gateway.create_link().apply(Operations.START_PULL, requested=request.requested)
     link_gateway.apply(result.updates)
     output_port(OperationResponse(result.operation, request.requested, result.updates, result.errors))
 
@@ -148,7 +146,7 @@ def start_delete_process(
     output_port: Callable[[OperationResponse], None],
 ) -> None:
     """Start the delete process for the requested entities."""
-    result = start_delete(link_gateway.create_link(), requested=request.requested)
+    result = link_gateway.create_link().apply(Operations.START_DELETE, requested=request.requested)
     link_gateway.apply(result.updates)
     output_port(OperationResponse(result.operation, request.requested, result.updates, result.errors))
 
@@ -164,7 +162,7 @@ def process(
     request: ProcessRequest, *, link_gateway: LinkGateway, output_port: Callable[[OperationResponse], None]
 ) -> None:
     """Process entities."""
-    result = process_domain_service(link_gateway.create_link(), requested=request.requested)
+    result = link_gateway.create_link().apply(Operations.PROCESS, requested=request.requested)
     link_gateway.apply(result.updates)
     output_port(OperationResponse(result.operation, request.requested, result.updates, result.errors))
 

--- a/link/service/uow.py
+++ b/link/service/uow.py
@@ -1,0 +1,86 @@
+"""Contains the unit of work for links."""
+from __future__ import annotations
+
+from abc import ABC
+from collections import defaultdict, deque
+from types import TracebackType
+from typing import Callable
+
+from link.domain.custom_types import Identifier
+from link.domain.link import Link
+from link.domain.state import TRANSITION_MAP, Entity, Operations, Transition, Update
+
+from .gateway import LinkGateway
+
+
+class UnitOfWork(ABC):
+    """Controls if and when updates to entities of a link are persisted."""
+
+    def __init__(self, gateway: LinkGateway) -> None:
+        """Initialize the unit of work."""
+        self._gateway = gateway
+        self._link: Link | None = None
+        self._updates: dict[Identifier, deque[Update]] = defaultdict(deque)
+        self._entities: dict[Identifier, Entity] = {}
+
+    def __enter__(self) -> UnitOfWork:
+        """Enter the context in which updates to entities can be made."""
+
+        def track_entity(entity: Entity) -> None:
+            apply = getattr(entity, "apply")
+            augmented = augment_apply(entity, apply)
+            object.__setattr__(entity, "apply", augmented)
+            self._entities[entity.identifier] = entity
+
+        def augment_apply(current: Entity, apply: Callable[[Operations], Entity]) -> Callable[[Operations], Entity]:
+            def track_and_apply(operation: Operations) -> Entity:
+                if self._link is None:
+                    raise RuntimeError
+                new = apply(operation)
+                store_update(operation, current, new)
+                track_entity(new)
+                return new
+
+            return track_and_apply
+
+        def store_update(operation: Operations, current: Entity, new: Entity) -> None:
+            assert current.identifier == new.identifier
+            if current.state is new.state:
+                return
+            transition = Transition(current.state, new.state)
+            self._updates[current.identifier].append(
+                Update(operation, current.identifier, transition, TRANSITION_MAP[transition])
+            )
+
+        link = self._gateway.create_link()
+        for entity in link:
+            track_entity(entity)
+        self._link = link
+        return self
+
+    def __exit__(
+        self, exc_type: type[BaseException] | None, exc: BaseException | None, traceback: TracebackType | None
+    ) -> None:
+        """Exit the context rolling back any not yet persisted updates."""
+        self.rollback()
+
+    @property
+    def link(self) -> Link:
+        """Return the link object that is governed by this unit of work."""
+        if self._link is None:
+            raise RuntimeError
+        return self._link
+
+    def commit(self) -> None:
+        """Persist updates made to the link."""
+        while self._updates:
+            identifier, updates = self._updates.popitem()
+            while updates:
+                self._gateway.apply([updates.popleft()])
+        self._link = None
+
+    def rollback(self) -> None:
+        """Throw away any not yet persisted updates."""
+        self._link = None
+        self._entities = {}
+        self._updates = defaultdict(deque)

--- a/tests/integration/gateway.py
+++ b/tests/integration/gateway.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Iterable
+
+from link.domain.custom_types import Identifier
+from link.domain.link import Link, create_link
+from link.domain.state import Commands, Components, Processes, Update
+from link.service.gateway import LinkGateway
+
+
+class FakeLinkGateway(LinkGateway):
+    def __init__(
+        self,
+        assignments: Mapping[Components, Iterable[Identifier]],
+        *,
+        tainted_identifiers: Iterable[Identifier] | None = None,
+        processes: Mapping[Processes, Iterable[Identifier]] | None = None,
+    ) -> None:
+        self.assignments = {component: set(identifiers) for component, identifiers in assignments.items()}
+        self.tainted_identifiers = set(tainted_identifiers) if tainted_identifiers is not None else set()
+        self.processes: dict[Processes, set[Identifier]] = {process: set() for process in Processes}
+        if processes is not None:
+            for entity_process, identifiers in processes.items():
+                self.processes[entity_process].update(identifiers)
+
+    def create_link(self) -> Link:
+        return create_link(self.assignments, tainted_identifiers=self.tainted_identifiers, processes=self.processes)
+
+    def apply(self, updates: Iterable[Update]) -> None:
+        for update in updates:
+            if update.command is Commands.START_PULL_PROCESS:
+                self.processes[Processes.PULL].add(update.identifier)
+                self.assignments[Components.OUTBOUND].add(update.identifier)
+            elif update.command is Commands.ADD_TO_LOCAL:
+                self.assignments[Components.LOCAL].add(update.identifier)
+            elif update.command is Commands.FINISH_PULL_PROCESS:
+                self.processes[Processes.PULL].remove(update.identifier)
+            elif update.command is Commands.START_DELETE_PROCESS:
+                self.processes[Processes.DELETE].add(update.identifier)
+            elif update.command is Commands.REMOVE_FROM_LOCAL:
+                self.assignments[Components.LOCAL].remove(update.identifier)
+            elif update.command is Commands.FINISH_DELETE_PROCESS:
+                self.processes[Processes.DELETE].remove(update.identifier)
+                self.assignments[Components.OUTBOUND].remove(update.identifier)
+            elif update.command is Commands.DEPRECATE:
+                try:
+                    self.processes[Processes.DELETE].remove(update.identifier)
+                except KeyError:
+                    self.processes[Processes.PULL].remove(update.identifier)
+            else:
+                raise ValueError("Unsupported command encountered")

--- a/tests/integration/test_datajoint_persistence.py
+++ b/tests/integration/test_datajoint_persistence.py
@@ -371,7 +371,10 @@ def test_add_to_local_command() -> None:
     )
 
     gateway.apply(
-        gateway.create_link().apply(Operations.PROCESS, requested={gateway.translator.to_identifier({"a": 0})}).updates
+        gateway.create_link()
+        .apply(Operations.PROCESS, requested={gateway.translator.to_identifier({"a": 0})})
+        .operation_results[0]
+        .updates
     )
 
     assert has_state(
@@ -413,6 +416,7 @@ def test_add_to_local_command_with_error() -> None:
         gateway.apply(
             gateway.create_link()
             .apply(Operations.PROCESS, requested={gateway.translator.to_identifier({"a": 0})})
+            .operation_results[0]
             .updates
         )
     except RuntimeError:
@@ -432,7 +436,10 @@ def test_add_to_local_command_with_external_file(tmpdir: Path) -> None:
     os.remove(insert_filepath)
     tables["outbound"].insert([{"a": 0, "process": "PULL", "is_flagged": "FALSE", "is_deprecated": "FALSE"}])
     gateway.apply(
-        gateway.create_link().apply(Operations.PROCESS, requested={gateway.translator.to_identifier({"a": 0})}).updates
+        gateway.create_link()
+        .apply(Operations.PROCESS, requested={gateway.translator.to_identifier({"a": 0})})
+        .operation_results[0]
+        .updates
     )
     fetch_filepath = Path(tables["local"].fetch(as_dict=True, download_path=str(tmpdir))[0]["external"])
     with fetch_filepath.open(mode="rb") as file:
@@ -455,6 +462,7 @@ def test_remove_from_local_command() -> None:
         gateway.apply(
             gateway.create_link()
             .apply(Operations.PROCESS, requested={gateway.translator.to_identifier({"a": 0})})
+            .operation_results[0]
             .updates
         )
 
@@ -475,6 +483,7 @@ def test_start_pull_process() -> None:
     gateway.apply(
         gateway.create_link()
         .apply(Operations.START_PULL, requested={gateway.translator.to_identifier({"a": 0})})
+        .operation_results[0]
         .updates
     )
 
@@ -504,6 +513,7 @@ class TestFinishPullProcessCommand:
         gateway.apply(
             gateway.create_link()
             .apply(Operations.PROCESS, requested={gateway.translator.to_identifier({"a": 0})})
+            .operation_results[0]
             .updates
         )
 
@@ -525,6 +535,7 @@ class TestFinishPullProcessCommand:
             gateway.apply(
                 gateway.create_link()
                 .apply(Operations.PROCESS, requested={gateway.translator.to_identifier({"a": 0})})
+                .operation_results[0]
                 .updates
             )
         except RuntimeError:
@@ -550,6 +561,7 @@ class TestStartDeleteProcessCommand:
         gateway.apply(
             gateway.create_link()
             .apply(Operations.START_DELETE, requested={gateway.translator.to_identifier({"a": 0})})
+            .operation_results[0]
             .updates
         )
 
@@ -571,6 +583,7 @@ class TestStartDeleteProcessCommand:
             gateway.apply(
                 gateway.create_link()
                 .apply(Operations.START_DELETE, requested={gateway.translator.to_identifier({"a": 0})})
+                .operation_results[0]
                 .updates
             )
         except RuntimeError:
@@ -591,7 +604,10 @@ def test_finish_delete_process_command() -> None:
     )
 
     gateway.apply(
-        gateway.create_link().apply(Operations.PROCESS, requested={gateway.translator.to_identifier({"a": 0})}).updates
+        gateway.create_link()
+        .apply(Operations.PROCESS, requested={gateway.translator.to_identifier({"a": 0})})
+        .operation_results[0]
+        .updates
     )
 
     assert has_state(tables, State(source=TableState([{"a": 0, "b": 1}])))
@@ -613,6 +629,7 @@ class TestDeprecateProcessCommand:
         gateway.apply(
             gateway.create_link()
             .apply(Operations.PROCESS, requested={gateway.translator.to_identifier({"a": 0})})
+            .operation_results[0]
             .updates
         )
 
@@ -633,6 +650,7 @@ class TestDeprecateProcessCommand:
             gateway.apply(
                 gateway.create_link()
                 .apply(Operations.PROCESS, requested={gateway.translator.to_identifier({"a": 0})})
+                .operation_results[0]
                 .updates
             )
         except RuntimeError:
@@ -662,6 +680,7 @@ def test_applying_multiple_commands() -> None:
         gateway.apply(
             gateway.create_link()
             .apply(Operations.PROCESS, requested=gateway.translator.to_identifiers([{"a": 0}, {"a": 1}]))
+            .operation_results[0]
             .updates
         )
 

--- a/tests/integration/test_services.py
+++ b/tests/integration/test_services.py
@@ -1,15 +1,12 @@
 from __future__ import annotations
 
-from collections.abc import Callable, Iterable, Mapping
+from collections.abc import Callable
 from functools import partial
 from typing import Generic, TypedDict, TypeVar
 
 import pytest
 
-from link.domain.custom_types import Identifier
-from link.domain.link import Link, create_link
-from link.domain.state import Commands, Components, InvalidOperation, Operations, Processes, State, Update, states
-from link.service.gateway import LinkGateway
+from link.domain.state import Components, InvalidOperation, Operations, Processes, State, states
 from link.service.io import Service, make_responsive
 from link.service.services import (
     DeleteRequest,
@@ -33,49 +30,7 @@ from link.service.services import (
 from link.service.uow import UnitOfWork
 from tests.assignments import create_assignments, create_identifier, create_identifiers
 
-
-class FakeLinkGateway(LinkGateway):
-    def __init__(
-        self,
-        assignments: Mapping[Components, Iterable[Identifier]],
-        *,
-        tainted_identifiers: Iterable[Identifier] | None = None,
-        processes: Mapping[Processes, Iterable[Identifier]] | None = None,
-    ) -> None:
-        self.assignments = {component: set(identifiers) for component, identifiers in assignments.items()}
-        self.tainted_identifiers = set(tainted_identifiers) if tainted_identifiers is not None else set()
-        self.processes: dict[Processes, set[Identifier]] = {process: set() for process in Processes}
-        if processes is not None:
-            for entity_process, identifiers in processes.items():
-                self.processes[entity_process].update(identifiers)
-
-    def create_link(self) -> Link:
-        return create_link(self.assignments, tainted_identifiers=self.tainted_identifiers, processes=self.processes)
-
-    def apply(self, updates: Iterable[Update]) -> None:
-        for update in updates:
-            if update.command is Commands.START_PULL_PROCESS:
-                self.processes[Processes.PULL].add(update.identifier)
-                self.assignments[Components.OUTBOUND].add(update.identifier)
-            elif update.command is Commands.ADD_TO_LOCAL:
-                self.assignments[Components.LOCAL].add(update.identifier)
-            elif update.command is Commands.FINISH_PULL_PROCESS:
-                self.processes[Processes.PULL].remove(update.identifier)
-            elif update.command is Commands.START_DELETE_PROCESS:
-                self.processes[Processes.DELETE].add(update.identifier)
-            elif update.command is Commands.REMOVE_FROM_LOCAL:
-                self.assignments[Components.LOCAL].remove(update.identifier)
-            elif update.command is Commands.FINISH_DELETE_PROCESS:
-                self.processes[Processes.DELETE].remove(update.identifier)
-                self.assignments[Components.OUTBOUND].remove(update.identifier)
-            elif update.command is Commands.DEPRECATE:
-                try:
-                    self.processes[Processes.DELETE].remove(update.identifier)
-                except KeyError:
-                    self.processes[Processes.PULL].remove(update.identifier)
-            else:
-                raise ValueError("Unsupported command encountered")
-
+from .gateway import FakeLinkGateway
 
 T = TypeVar("T", bound=Response)
 

--- a/tests/integration/test_services.py
+++ b/tests/integration/test_services.py
@@ -30,6 +30,7 @@ from link.service.services import (
     start_delete_process,
     start_pull_process,
 )
+from link.service.uow import UnitOfWork
 from tests.assignments import create_assignments, create_identifier, create_identifiers
 
 
@@ -92,7 +93,7 @@ class FakeOutputPort(Generic[T]):
         self._response = response
 
 
-def create_gateway(state: type[State], process: Processes | None = None, is_tainted: bool = False) -> FakeLinkGateway:
+def create_uow(state: type[State], process: Processes | None = None, is_tainted: bool = False) -> UnitOfWork:
     if state in (states.Activated, states.Received):
         assert process is not None
     else:
@@ -112,22 +113,26 @@ def create_gateway(state: type[State], process: Processes | None = None, is_tain
         processes = {}
     assignments = {Components.SOURCE: {"1"}}
     if state is states.Idle:
-        return FakeLinkGateway(
-            create_assignments(assignments), tainted_identifiers=tainted_identifiers, processes=processes
+        return UnitOfWork(
+            FakeLinkGateway(
+                create_assignments(assignments), tainted_identifiers=tainted_identifiers, processes=processes
+            )
         )
     assignments[Components.OUTBOUND] = {"1"}
     if state in (states.Deprecated, states.Activated):
-        return FakeLinkGateway(
-            create_assignments(assignments), tainted_identifiers=tainted_identifiers, processes=processes
+        return UnitOfWork(
+            FakeLinkGateway(
+                create_assignments(assignments), tainted_identifiers=tainted_identifiers, processes=processes
+            )
         )
     assignments[Components.LOCAL] = {"1"}
-    return FakeLinkGateway(
-        create_assignments(assignments), tainted_identifiers=tainted_identifiers, processes=processes
+    return UnitOfWork(
+        FakeLinkGateway(create_assignments(assignments), tainted_identifiers=tainted_identifiers, processes=processes)
     )
 
 
-def create_process_to_completion_service(gateway: FakeLinkGateway) -> Callable[[ProcessToCompletionRequest], None]:
-    process_service = partial(make_responsive(partial(process, link_gateway=gateway)), output_port=lambda x: None)
+def create_process_to_completion_service(uow: UnitOfWork) -> Callable[[ProcessToCompletionRequest], None]:
+    process_service = partial(make_responsive(partial(process, uow=uow)), output_port=lambda x: None)
     return partial(
         make_responsive(
             partial(
@@ -139,10 +144,10 @@ def create_process_to_completion_service(gateway: FakeLinkGateway) -> Callable[[
     )
 
 
-def create_pull_service(gateway: FakeLinkGateway) -> Service[PullRequest, PullResponse]:
-    process_to_completion_service = create_process_to_completion_service(gateway)
+def create_pull_service(uow: UnitOfWork) -> Service[PullRequest, PullResponse]:
+    process_to_completion_service = create_process_to_completion_service(uow)
     start_pull_process_service = partial(
-        make_responsive(partial(start_pull_process, link_gateway=gateway)), output_port=lambda x: None
+        make_responsive(partial(start_pull_process, uow=uow)), output_port=lambda x: None
     )
     return partial(
         pull,
@@ -151,10 +156,10 @@ def create_pull_service(gateway: FakeLinkGateway) -> Service[PullRequest, PullRe
     )
 
 
-def create_delete_service(gateway: FakeLinkGateway) -> Service[DeleteRequest, DeleteResponse]:
-    process_to_completion_service = create_process_to_completion_service(gateway)
+def create_delete_service(uow: UnitOfWork) -> Service[DeleteRequest, DeleteResponse]:
+    process_to_completion_service = create_process_to_completion_service(uow)
     start_delete_process_service = partial(
-        make_responsive(partial(start_delete_process, link_gateway=gateway)), output_port=lambda x: None
+        make_responsive(partial(start_delete_process, uow=uow)), output_port=lambda x: None
     )
     return partial(
         delete,
@@ -203,18 +208,21 @@ STATES: list[EntityConfig] = [
     ],
 )
 def test_deleted_entity_ends_in_correct_state(state: EntityConfig, expected: type[State]) -> None:
-    gateway = create_gateway(**state)
-    delete_service = create_delete_service(gateway)
+    uow = create_uow(**state)
+    delete_service = create_delete_service(uow)
     delete_service(DeleteRequest(frozenset(create_identifiers("1"))), output_port=lambda x: None)
-    assert next(iter(gateway.create_link())).state is expected
+    with uow:
+        assert next(iter(uow.link)).state is expected
 
 
 def test_correct_response_model_gets_passed_to_delete_output_port() -> None:
-    gateway = FakeLinkGateway(
-        create_assignments({Components.SOURCE: {"1"}, Components.OUTBOUND: {"1"}, Components.LOCAL: {"1"}})
+    uow = UnitOfWork(
+        FakeLinkGateway(
+            create_assignments({Components.SOURCE: {"1"}, Components.OUTBOUND: {"1"}, Components.LOCAL: {"1"}})
+        )
     )
     output_port = FakeOutputPort[DeleteResponse]()
-    delete_service = create_delete_service(gateway)
+    delete_service = create_delete_service(uow)
     delete_service(DeleteRequest(frozenset(create_identifiers("1"))), output_port=output_port)
     assert output_port.response.requested == create_identifiers("1")
 
@@ -237,13 +245,14 @@ def test_correct_response_model_gets_passed_to_delete_output_port() -> None:
     ],
 )
 def test_pulled_entity_ends_in_correct_state(state: EntityConfig, expected: type[State]) -> None:
-    gateway = create_gateway(**state)
-    pull_service = create_pull_service(gateway)
+    uow = create_uow(**state)
+    pull_service = create_pull_service(uow)
     pull_service(
         PullRequest(frozenset(create_identifiers("1"))),
         output_port=lambda x: None,
     )
-    assert next(iter(gateway.create_link())).state is expected
+    with uow:
+        assert next(iter(uow.link)).state is expected
 
 
 @pytest.mark.parametrize(
@@ -272,7 +281,7 @@ def test_correct_response_model_gets_passed_to_pull_output_port(state: EntityCon
         }
     else:
         errors = set()
-    gateway = create_gateway(**state)
+    gateway = create_uow(**state)
     output_port = FakeOutputPort[PullResponse]()
     pull_service = create_pull_service(gateway)
     pull_service(
@@ -283,28 +292,33 @@ def test_correct_response_model_gets_passed_to_pull_output_port(state: EntityCon
 
 
 def test_entity_undergoing_process_gets_processed() -> None:
-    gateway = FakeLinkGateway(
-        create_assignments({Components.SOURCE: {"1"}, Components.OUTBOUND: {"1"}}),
-        processes={Processes.PULL: create_identifiers("1")},
+    uow = UnitOfWork(
+        FakeLinkGateway(
+            create_assignments({Components.SOURCE: {"1"}, Components.OUTBOUND: {"1"}}),
+            processes={Processes.PULL: create_identifiers("1")},
+        )
     )
     process(
         ProcessRequest(frozenset(create_identifiers("1"))),
-        link_gateway=gateway,
+        uow=uow,
         output_port=FakeOutputPort[OperationResponse](),
     )
-    entity = next(entity for entity in gateway.create_link() if entity.identifier == create_identifier("1"))
-    assert entity.state is states.Received
+    with uow:
+        entity = next(entity for entity in uow.link if entity.identifier == create_identifier("1"))
+        assert entity.state is states.Received
 
 
 def test_correct_response_model_gets_passed_to_process_output_port() -> None:
-    gateway = FakeLinkGateway(
-        create_assignments({Components.SOURCE: {"1"}, Components.OUTBOUND: {"1"}}),
-        processes={Processes.PULL: create_identifiers("1")},
+    uow = UnitOfWork(
+        FakeLinkGateway(
+            create_assignments({Components.SOURCE: {"1"}, Components.OUTBOUND: {"1"}}),
+            processes={Processes.PULL: create_identifiers("1")},
+        )
     )
     output_port = FakeOutputPort[OperationResponse]()
     process(
         ProcessRequest(frozenset(create_identifiers("1"))),
-        link_gateway=gateway,
+        uow=uow,
         output_port=output_port,
     )
     assert output_port.response.requested == create_identifiers("1")
@@ -312,9 +326,11 @@ def test_correct_response_model_gets_passed_to_process_output_port() -> None:
 
 
 def test_correct_response_model_gets_passed_to_list_idle_entities_output_port() -> None:
-    link_gateway = FakeLinkGateway(
-        create_assignments({Components.SOURCE: {"1", "2"}, Components.OUTBOUND: {"2"}, Components.LOCAL: {"2"}})
+    uow = UnitOfWork(
+        FakeLinkGateway(
+            create_assignments({Components.SOURCE: {"1", "2"}, Components.OUTBOUND: {"2"}, Components.LOCAL: {"2"}})
+        )
     )
     output_port = FakeOutputPort[ListIdleEntitiesResponse]()
-    list_idle_entities(ListIdleEntitiesRequest(), link_gateway=link_gateway, output_port=output_port)
+    list_idle_entities(ListIdleEntitiesRequest(), uow=uow, output_port=output_port)
     assert set(output_port.response.identifiers) == create_identifiers("1")

--- a/tests/integration/test_uow.py
+++ b/tests/integration/test_uow.py
@@ -19,10 +19,10 @@ def initialize(assignments: Mapping[Components, Iterable[str]]) -> tuple[FakeLin
 def test_updates_are_applied_to_gateway_on_commit() -> None:
     gateway, uow = initialize({Components.SOURCE: {"1", "2"}, Components.OUTBOUND: {"2"}, Components.LOCAL: {"2"}})
     with uow:
-        link = uow.link.apply(Operations.START_PULL, requested=create_identifiers("1"))
-        link = link.apply(Operations.START_DELETE, requested=create_identifiers("2"))
-        link = link.apply(Operations.PROCESS, requested=create_identifiers("1", "2"))
-        link.apply(Operations.PROCESS, requested=create_identifiers("1", "2"))
+        uow.link.apply(Operations.START_PULL, requested=create_identifiers("1"))
+        uow.link.apply(Operations.START_DELETE, requested=create_identifiers("2"))
+        uow.link.apply(Operations.PROCESS, requested=create_identifiers("1", "2"))
+        uow.link.apply(Operations.PROCESS, requested=create_identifiers("1", "2"))
         uow.commit()
     actual = {(entity.identifier, entity.state) for entity in gateway.create_link()}
     expected = {(create_identifier("1"), states.Pulled), (create_identifier("2"), states.Idle)}
@@ -32,10 +32,10 @@ def test_updates_are_applied_to_gateway_on_commit() -> None:
 def test_updates_are_discarded_on_context_exit() -> None:
     gateway, uow = initialize({Components.SOURCE: {"1", "2"}, Components.OUTBOUND: {"2"}, Components.LOCAL: {"2"}})
     with uow:
-        link = uow.link.apply(Operations.START_PULL, requested=create_identifiers("1"))
-        link = link.apply(Operations.START_DELETE, requested=create_identifiers("2"))
-        link = link.apply(Operations.PROCESS, requested=create_identifiers("1", "2"))
-        link.apply(Operations.PROCESS, requested=create_identifiers("1", "2"))
+        uow.link.apply(Operations.START_PULL, requested=create_identifiers("1"))
+        uow.link.apply(Operations.START_DELETE, requested=create_identifiers("2"))
+        uow.link.apply(Operations.PROCESS, requested=create_identifiers("1", "2"))
+        uow.link.apply(Operations.PROCESS, requested=create_identifiers("1", "2"))
     actual = {(entity.identifier, entity.state) for entity in gateway.create_link()}
     expected = {(create_identifier("1"), states.Idle), (create_identifier("2"), states.Pulled)}
     assert actual == expected
@@ -44,10 +44,10 @@ def test_updates_are_discarded_on_context_exit() -> None:
 def test_updates_are_discarded_on_rollback() -> None:
     gateway, uow = initialize({Components.SOURCE: {"1", "2"}, Components.OUTBOUND: {"2"}, Components.LOCAL: {"2"}})
     with uow:
-        link = uow.link.apply(Operations.START_PULL, requested=create_identifiers("1"))
-        link = link.apply(Operations.START_DELETE, requested=create_identifiers("2"))
-        link = link.apply(Operations.PROCESS, requested=create_identifiers("1", "2"))
-        link.apply(Operations.PROCESS, requested=create_identifiers("1", "2"))
+        uow.link.apply(Operations.START_PULL, requested=create_identifiers("1"))
+        uow.link.apply(Operations.START_DELETE, requested=create_identifiers("2"))
+        uow.link.apply(Operations.PROCESS, requested=create_identifiers("1", "2"))
+        uow.link.apply(Operations.PROCESS, requested=create_identifiers("1", "2"))
         uow.rollback()
     actual = {(entity.identifier, entity.state) for entity in gateway.create_link()}
     expected = {(create_identifier("1"), states.Idle), (create_identifier("2"), states.Pulled)}
@@ -56,31 +56,89 @@ def test_updates_are_discarded_on_rollback() -> None:
 
 def test_link_can_not_be_accessed_outside_of_context() -> None:
     _, uow = initialize({Components.SOURCE: {"1"}})
+    with uow:
+        pass
     with pytest.raises(RuntimeError, match="outside"):
-        uow.link.apply(Operations.START_PULL, requested=create_identifiers("1"))
+        uow.link
 
 
-def test_no_more_operations_can_be_applied_after_commit() -> None:
+def test_unable_to_commit_outside_of_context() -> None:
     _, uow = initialize({Components.SOURCE: {"1"}})
-    with uow:
-        link = uow.link.apply(Operations.START_PULL, requested=create_identifiers("1"))
+    with pytest.raises(RuntimeError, match="outside"):
         uow.commit()
-        with pytest.raises(RuntimeError, match="expired"):
-            link.apply(Operations.PROCESS, requested=create_identifiers("1"))
 
 
-def test_no_more_operations_can_be_applied_after_rollback() -> None:
+def test_unable_to_rollback_outside_of_context() -> None:
+    _, uow = initialize({Components.SOURCE: {"1"}})
+    with pytest.raises(RuntimeError, match="outside"):
+        uow.rollback()
+
+
+def test_entity_expires_when_committing() -> None:
     _, uow = initialize({Components.SOURCE: {"1"}})
     with uow:
-        link = uow.link.apply(Operations.START_PULL, requested=create_identifiers("1"))
+        entity = next(entity for entity in uow.link if entity.identifier == create_identifier("1"))
+        uow.commit()
+        with pytest.raises(RuntimeError, match="expired entity"):
+            entity.apply(Operations.START_PULL)
+
+
+def test_entity_expires_when_rolling_back() -> None:
+    _, uow = initialize({Components.SOURCE: {"1"}})
+    with uow:
+        entity = next(entity for entity in uow.link if entity.identifier == create_identifier("1"))
         uow.rollback()
-        with pytest.raises(RuntimeError, match="expired"):
+        with pytest.raises(RuntimeError, match="expired entity"):
+            entity.apply(Operations.START_PULL)
+
+
+def test_entity_expires_when_leaving_context() -> None:
+    _, uow = initialize({Components.SOURCE: {"1"}})
+    with uow:
+        entity = next(entity for entity in uow.link if entity.identifier == create_identifier("1"))
+    with pytest.raises(RuntimeError, match="expired entity"):
+        entity.apply(Operations.START_PULL)
+
+
+def test_entity_expires_when_applying_operation() -> None:
+    _, uow = initialize({Components.SOURCE: {"1"}})
+    with uow:
+        entity = next(entity for entity in uow.link if entity.identifier == create_identifier("1"))
+        entity.apply(Operations.START_PULL)
+        with pytest.raises(RuntimeError, match="expired entity"):
+            entity.apply(Operations.PROCESS)
+
+
+def test_link_expires_when_committing() -> None:
+    _, uow = initialize({Components.SOURCE: {"1"}})
+    with uow:
+        link = uow.link
+        uow.commit()
+        with pytest.raises(RuntimeError, match="expired link"):
             link.apply(Operations.START_PULL, requested=create_identifiers("1"))
 
 
-def test_no_more_operations_can_be_applied_after_exiting_context() -> None:
+def test_link_expires_when_rolling_back() -> None:
     _, uow = initialize({Components.SOURCE: {"1"}})
     with uow:
-        link = uow.link.apply(Operations.START_PULL, requested=create_identifiers("1"))
-    with pytest.raises(RuntimeError, match="expired"):
+        link = uow.link
+        uow.rollback()
+        with pytest.raises(RuntimeError, match="expired link"):
+            link.apply(Operations.START_PULL, requested=create_identifiers("1"))
+
+
+def test_link_expires_when_exiting_context() -> None:
+    _, uow = initialize({Components.SOURCE: {"1"}})
+    with uow:
+        link = uow.link
+    with pytest.raises(RuntimeError, match="expired link"):
         link.apply(Operations.START_PULL, requested=create_identifiers("1"))
+
+
+def test_link_expires_when_applying_operation() -> None:
+    _, uow = initialize({Components.SOURCE: {"1"}})
+    with uow:
+        link = uow.link
+        link.apply(Operations.START_PULL, requested=create_identifiers("1"))
+        with pytest.raises(RuntimeError, match="expired link"):
+            link.apply(Operations.PROCESS, requested=create_identifiers("1"))

--- a/tests/integration/test_uow.py
+++ b/tests/integration/test_uow.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from typing import Iterable, Mapping
+
+import pytest
+
+from link.domain.state import Components, Operations, states
+from link.service.uow import UnitOfWork
+from tests.assignments import create_assignments, create_identifier, create_identifiers
+
+from .gateway import FakeLinkGateway
+
+
+def initialize(assignments: Mapping[Components, Iterable[str]]) -> tuple[FakeLinkGateway, UnitOfWork]:
+    gateway = FakeLinkGateway(create_assignments(assignments))
+    return gateway, UnitOfWork(gateway)
+
+
+def test_updates_are_applied_to_gateway_on_commit() -> None:
+    gateway, uow = initialize({Components.SOURCE: {"1", "2"}, Components.OUTBOUND: {"2"}, Components.LOCAL: {"2"}})
+    with uow:
+        link = uow.link.apply(Operations.START_PULL, requested=create_identifiers("1"))
+        link = link.apply(Operations.START_DELETE, requested=create_identifiers("2"))
+        link = link.apply(Operations.PROCESS, requested=create_identifiers("1", "2"))
+        link.apply(Operations.PROCESS, requested=create_identifiers("1", "2"))
+        uow.commit()
+    actual = {(entity.identifier, entity.state) for entity in gateway.create_link()}
+    expected = {(create_identifier("1"), states.Pulled), (create_identifier("2"), states.Idle)}
+    assert actual == expected
+
+
+def test_updates_are_discarded_on_context_exit() -> None:
+    gateway, uow = initialize({Components.SOURCE: {"1", "2"}, Components.OUTBOUND: {"2"}, Components.LOCAL: {"2"}})
+    with uow:
+        link = uow.link.apply(Operations.START_PULL, requested=create_identifiers("1"))
+        link = link.apply(Operations.START_DELETE, requested=create_identifiers("2"))
+        link = link.apply(Operations.PROCESS, requested=create_identifiers("1", "2"))
+        link.apply(Operations.PROCESS, requested=create_identifiers("1", "2"))
+    actual = {(entity.identifier, entity.state) for entity in gateway.create_link()}
+    expected = {(create_identifier("1"), states.Idle), (create_identifier("2"), states.Pulled)}
+    assert actual == expected
+
+
+def test_updates_are_discarded_on_rollback() -> None:
+    gateway, uow = initialize({Components.SOURCE: {"1", "2"}, Components.OUTBOUND: {"2"}, Components.LOCAL: {"2"}})
+    with uow:
+        link = uow.link.apply(Operations.START_PULL, requested=create_identifiers("1"))
+        link = link.apply(Operations.START_DELETE, requested=create_identifiers("2"))
+        link = link.apply(Operations.PROCESS, requested=create_identifiers("1", "2"))
+        link.apply(Operations.PROCESS, requested=create_identifiers("1", "2"))
+        uow.rollback()
+    actual = {(entity.identifier, entity.state) for entity in gateway.create_link()}
+    expected = {(create_identifier("1"), states.Idle), (create_identifier("2"), states.Pulled)}
+    assert actual == expected
+
+
+def test_link_can_not_be_accessed_outside_of_context() -> None:
+    _, uow = initialize({Components.SOURCE: {"1"}})
+    with pytest.raises(RuntimeError, match="outside"):
+        uow.link.apply(Operations.START_PULL, requested=create_identifiers("1"))
+
+
+def test_no_more_operations_can_be_applied_after_commit() -> None:
+    _, uow = initialize({Components.SOURCE: {"1"}})
+    with uow:
+        link = uow.link.apply(Operations.START_PULL, requested=create_identifiers("1"))
+        uow.commit()
+        with pytest.raises(RuntimeError, match="expired"):
+            link.apply(Operations.PROCESS, requested=create_identifiers("1"))
+
+
+def test_no_more_operations_can_be_applied_after_rollback() -> None:
+    _, uow = initialize({Components.SOURCE: {"1"}})
+    with uow:
+        link = uow.link.apply(Operations.START_PULL, requested=create_identifiers("1"))
+        uow.rollback()
+        with pytest.raises(RuntimeError, match="expired"):
+            link.apply(Operations.START_PULL, requested=create_identifiers("1"))
+
+
+def test_no_more_operations_can_be_applied_after_exiting_context() -> None:
+    _, uow = initialize({Components.SOURCE: {"1"}})
+    with uow:
+        link = uow.link.apply(Operations.START_PULL, requested=create_identifiers("1"))
+    with pytest.raises(RuntimeError, match="expired"):
+        link.apply(Operations.START_PULL, requested=create_identifiers("1"))

--- a/tests/unit/entities/test_link.py
+++ b/tests/unit/entities/test_link.py
@@ -79,7 +79,7 @@ class TestCreateLink:
             (create_identifier("2"), Processes.DELETE),
             (create_identifier("3"), Processes.PULL),
             (create_identifier("4"), Processes.DELETE),
-            (create_identifier("5"), None),
+            (create_identifier("5"), Processes.NONE),
         }
         assert {(entity.identifier, entity.current_process) for entity in link} == set(expected)
 

--- a/tests/unit/entities/test_link.py
+++ b/tests/unit/entities/test_link.py
@@ -6,8 +6,8 @@ from typing import ContextManager, Iterable, Mapping
 import pytest
 
 from link.domain.custom_types import Identifier
-from link.domain.link import Link, create_link, process, start_delete, start_pull
-from link.domain.state import Components, Processes, State, states
+from link.domain.link import Link, create_link
+from link.domain.state import Components, Operations, Processes, State, states
 from tests.assignments import create_assignments, create_identifier, create_identifiers
 
 
@@ -183,7 +183,7 @@ def test_process_produces_correct_updates() -> None:
     )
     actual = {
         (update.identifier, update.transition.new)
-        for update in process(link, requested=create_identifiers("1", "2", "3", "4")).updates
+        for update in link.apply(Operations.PROCESS, requested=create_identifiers("1", "2", "3", "4")).updates
     }
     expected = {
         (create_identifier("1"), states.Received),
@@ -202,7 +202,7 @@ class TestStartPull:
 
     @staticmethod
     def test_idle_entity_becomes_activated(link: Link) -> None:
-        result = start_pull(link, requested=create_identifiers("1"))
+        result = link.apply(Operations.START_PULL, requested=create_identifiers("1"))
         update = next(iter(result.updates))
         assert update.identifier == create_identifier("1")
         assert update.transition.new is states.Activated
@@ -210,12 +210,12 @@ class TestStartPull:
     @staticmethod
     def test_not_specifying_requested_identifiers_raises_error(link: Link) -> None:
         with pytest.raises(AssertionError, match="No identifiers requested."):
-            start_pull(link, requested={})
+            link.apply(Operations.START_PULL, requested={})
 
     @staticmethod
     def test_specifying_identifiers_not_present_in_link_raises_error(link: Link) -> None:
         with pytest.raises(AssertionError, match="Requested identifiers not present in link."):
-            start_pull(link, requested=create_identifiers("2"))
+            link.apply(Operations.START_PULL, requested=create_identifiers("2"))
 
 
 @pytest.fixture()
@@ -228,7 +228,7 @@ def link() -> Link:
 class TestStartDelete:
     @staticmethod
     def test_pulled_entity_becomes_received(link: Link) -> None:
-        result = start_delete(link, requested=create_identifiers("1"))
+        result = link.apply(Operations.START_DELETE, requested=create_identifiers("1"))
         update = next(iter(result.updates))
         assert {update.identifier} == create_identifiers("1")
         assert update.transition.new is states.Received
@@ -236,9 +236,9 @@ class TestStartDelete:
     @staticmethod
     def test_not_specifying_requested_identifiers_raises_error(link: Link) -> None:
         with pytest.raises(AssertionError, match="No identifiers requested."):
-            start_delete(link, requested={})
+            link.apply(Operations.START_DELETE, requested={})
 
     @staticmethod
     def test_specifying_identifiers_not_present_in_link_raises_error(link: Link) -> None:
         with pytest.raises(AssertionError, match="Requested identifiers not present in link."):
-            start_delete(link, requested=create_identifiers("2"))
+            link.apply(Operations.START_DELETE, requested=create_identifiers("2"))

--- a/tests/unit/entities/test_state.py
+++ b/tests/unit/entities/test_state.py
@@ -7,7 +7,17 @@ import pytest
 
 from link.domain.custom_types import Identifier
 from link.domain.link import create_link
-from link.domain.state import Components, Operations, Processes, State, states
+from link.domain.state import (
+    Commands,
+    Components,
+    InvalidOperation,
+    Operations,
+    Processes,
+    State,
+    Transition,
+    Update,
+    states,
+)
 from tests.assignments import create_assignments, create_identifier, create_identifiers
 
 
@@ -41,31 +51,44 @@ def test_invalid_transitions_returns_unchanged_entity(
         processes={Processes.PULL: create_identifiers("2", "3")},
     )
     entity = next(entity for entity in link if entity.identifier == identifier)
-    assert all(entity.apply(operation) == entity for operation in operations)
+    for operation in operations:
+        result = InvalidOperation(operation, identifier, state)
+        assert entity.apply(operation) == replace(entity, operation_results=(result,))
 
 
 def test_start_pulling_idle_entity_returns_correct_entity() -> None:
     link = create_link(create_assignments({Components.SOURCE: {"1"}}))
     entity = next(iter(link))
     assert entity.apply(Operations.START_PULL) == replace(
-        entity, state=states.Activated, current_process=Processes.PULL
+        entity,
+        state=states.Activated,
+        current_process=Processes.PULL,
+        operation_results=(
+            Update(
+                Operations.START_PULL,
+                entity.identifier,
+                Transition(states.Idle, states.Activated),
+                Commands.START_PULL_PROCESS,
+            ),
+        ),
     )
 
 
 @pytest.mark.parametrize(
-    ("process", "tainted_identifiers", "new_state", "new_process"),
+    ("process", "tainted_identifiers", "new_state", "new_process", "command"),
     [
-        (Processes.PULL, set(), states.Received, Processes.PULL),
-        (Processes.PULL, create_identifiers("1"), states.Deprecated, None),
-        (Processes.DELETE, set(), states.Idle, None),
-        (Processes.DELETE, create_identifiers("1"), states.Deprecated, None),
+        (Processes.PULL, set(), states.Received, Processes.PULL, Commands.ADD_TO_LOCAL),
+        (Processes.PULL, create_identifiers("1"), states.Deprecated, Processes.NONE, Commands.DEPRECATE),
+        (Processes.DELETE, set(), states.Idle, Processes.NONE, Commands.FINISH_DELETE_PROCESS),
+        (Processes.DELETE, create_identifiers("1"), states.Deprecated, Processes.NONE, Commands.DEPRECATE),
     ],
 )
 def test_processing_activated_entity_returns_correct_entity(
     process: Processes,
     tainted_identifiers: Iterable[Identifier],
     new_state: type[State],
-    new_process: Processes | None,
+    new_process: Processes,
+    command: Commands,
 ) -> None:
     link = create_link(
         create_assignments({Components.SOURCE: {"1"}, Components.OUTBOUND: {"1"}}),
@@ -73,20 +96,29 @@ def test_processing_activated_entity_returns_correct_entity(
         tainted_identifiers=tainted_identifiers,
     )
     entity = next(iter(link))
-    assert entity.apply(Operations.PROCESS) == replace(entity, state=new_state, current_process=new_process)
+    updated_results = entity.operation_results + (
+        Update(Operations.PROCESS, entity.identifier, Transition(entity.state, new_state), command),
+    )
+    assert entity.apply(Operations.PROCESS) == replace(
+        entity, state=new_state, current_process=new_process, operation_results=updated_results
+    )
 
 
 @pytest.mark.parametrize(
-    ("process", "tainted_identifiers", "new_state", "new_process"),
+    ("process", "tainted_identifiers", "new_state", "new_process", "command"),
     [
-        (Processes.PULL, set(), states.Pulled, None),
-        (Processes.PULL, create_identifiers("1"), states.Tainted, None),
-        (Processes.DELETE, set(), states.Activated, Processes.DELETE),
-        (Processes.DELETE, create_identifiers("1"), states.Activated, Processes.DELETE),
+        (Processes.PULL, set(), states.Pulled, Processes.NONE, Commands.FINISH_PULL_PROCESS),
+        (Processes.PULL, create_identifiers("1"), states.Tainted, Processes.NONE, Commands.FINISH_PULL_PROCESS),
+        (Processes.DELETE, set(), states.Activated, Processes.DELETE, Commands.REMOVE_FROM_LOCAL),
+        (Processes.DELETE, create_identifiers("1"), states.Activated, Processes.DELETE, Commands.REMOVE_FROM_LOCAL),
     ],
 )
 def test_processing_received_entity_returns_correct_entity(
-    process: Processes, tainted_identifiers: Iterable[Identifier], new_state: type[State], new_process: Processes | None
+    process: Processes,
+    tainted_identifiers: Iterable[Identifier],
+    new_state: type[State],
+    new_process: Processes,
+    command: Commands,
 ) -> None:
     link = create_link(
         create_assignments({Components.SOURCE: {"1"}, Components.OUTBOUND: {"1"}, Components.LOCAL: {"1"}}),
@@ -94,7 +126,10 @@ def test_processing_received_entity_returns_correct_entity(
         tainted_identifiers=tainted_identifiers,
     )
     entity = next(iter(link))
-    assert entity.apply(Operations.PROCESS) == replace(entity, state=new_state, current_process=new_process)
+    operation_results = (Update(Operations.PROCESS, entity.identifier, Transition(entity.state, new_state), command),)
+    assert entity.apply(Operations.PROCESS) == replace(
+        entity, state=new_state, current_process=new_process, operation_results=operation_results
+    )
 
 
 def test_starting_delete_on_pulled_entity_returns_correct_entity() -> None:
@@ -102,8 +137,17 @@ def test_starting_delete_on_pulled_entity_returns_correct_entity() -> None:
         create_assignments({Components.SOURCE: {"1"}, Components.OUTBOUND: {"1"}, Components.LOCAL: {"1"}})
     )
     entity = next(iter(link))
+    transition = Transition(states.Pulled, states.Received)
+    operation_results = (
+        Update(
+            Operations.START_DELETE,
+            entity.identifier,
+            transition,
+            Commands.START_DELETE_PROCESS,
+        ),
+    )
     assert entity.apply(Operations.START_DELETE) == replace(
-        entity, state=states.Received, current_process=Processes.DELETE
+        entity, state=transition.new, current_process=Processes.DELETE, operation_results=operation_results
     )
 
 
@@ -113,6 +157,8 @@ def test_starting_delete_on_tainted_entity_returns_correct_commands() -> None:
         tainted_identifiers={create_identifier("1")},
     )
     entity = next(iter(link))
+    transition = Transition(states.Tainted, states.Received)
+    operation_results = (Update(Operations.START_DELETE, entity.identifier, transition, Commands.START_DELETE_PROCESS),)
     assert entity.apply(Operations.START_DELETE) == replace(
-        entity, state=states.Received, current_process=Processes.DELETE
+        entity, state=transition.new, current_process=Processes.DELETE, operation_results=operation_results
     )

--- a/tests/unit/entities/test_state.py
+++ b/tests/unit/entities/test_state.py
@@ -7,27 +7,28 @@ import pytest
 
 from link.domain.custom_types import Identifier
 from link.domain.link import create_link
-from link.domain.state import (
-    Components,
-    Processes,
-    State,
-    states,
-)
+from link.domain.state import Components, Operations, Processes, State, states
 from tests.assignments import create_assignments, create_identifier, create_identifiers
 
 
 @pytest.mark.parametrize(
-    ("identifier", "state", "methods"),
+    ("identifier", "state", "operations"),
     [
-        (create_identifier("1"), states.Idle, ["start_delete", "process"]),
-        (create_identifier("2"), states.Activated, ["start_pull", "start_delete"]),
-        (create_identifier("3"), states.Received, ["start_pull", "start_delete"]),
-        (create_identifier("4"), states.Pulled, ["start_pull", "process"]),
-        (create_identifier("5"), states.Tainted, ["start_pull", "process"]),
-        (create_identifier("6"), states.Deprecated, ["start_pull", "start_delete", "process"]),
+        (create_identifier("1"), states.Idle, [Operations.START_DELETE, Operations.PROCESS]),
+        (create_identifier("2"), states.Activated, [Operations.START_PULL, Operations.START_DELETE]),
+        (create_identifier("3"), states.Received, [Operations.START_PULL, Operations.START_DELETE]),
+        (create_identifier("4"), states.Pulled, [Operations.START_PULL, Operations.PROCESS]),
+        (create_identifier("5"), states.Tainted, [Operations.START_PULL, Operations.PROCESS]),
+        (
+            create_identifier("6"),
+            states.Deprecated,
+            [Operations.START_PULL, Operations.START_DELETE, Operations.PROCESS],
+        ),
     ],
 )
-def test_invalid_transitions_returns_unchanged_entity(identifier: Identifier, state: type[State], methods: str) -> None:
+def test_invalid_transitions_returns_unchanged_entity(
+    identifier: Identifier, state: type[State], operations: list[Operations]
+) -> None:
     link = create_link(
         create_assignments(
             {
@@ -40,13 +41,15 @@ def test_invalid_transitions_returns_unchanged_entity(identifier: Identifier, st
         processes={Processes.PULL: create_identifiers("2", "3")},
     )
     entity = next(entity for entity in link if entity.identifier == identifier)
-    assert all(getattr(entity, method)() == entity for method in methods)
+    assert all(entity.apply(operation) == entity for operation in operations)
 
 
 def test_start_pulling_idle_entity_returns_correct_entity() -> None:
     link = create_link(create_assignments({Components.SOURCE: {"1"}}))
     entity = next(iter(link))
-    assert entity.start_pull() == replace(entity, state=states.Activated, current_process=Processes.PULL)
+    assert entity.apply(Operations.START_PULL) == replace(
+        entity, state=states.Activated, current_process=Processes.PULL
+    )
 
 
 @pytest.mark.parametrize(
@@ -70,7 +73,7 @@ def test_processing_activated_entity_returns_correct_entity(
         tainted_identifiers=tainted_identifiers,
     )
     entity = next(iter(link))
-    assert entity.process() == replace(entity, state=new_state, current_process=new_process)
+    assert entity.apply(Operations.PROCESS) == replace(entity, state=new_state, current_process=new_process)
 
 
 @pytest.mark.parametrize(
@@ -91,7 +94,7 @@ def test_processing_received_entity_returns_correct_entity(
         tainted_identifiers=tainted_identifiers,
     )
     entity = next(iter(link))
-    assert entity.process() == replace(entity, state=new_state, current_process=new_process)
+    assert entity.apply(Operations.PROCESS) == replace(entity, state=new_state, current_process=new_process)
 
 
 def test_starting_delete_on_pulled_entity_returns_correct_entity() -> None:
@@ -99,7 +102,9 @@ def test_starting_delete_on_pulled_entity_returns_correct_entity() -> None:
         create_assignments({Components.SOURCE: {"1"}, Components.OUTBOUND: {"1"}, Components.LOCAL: {"1"}})
     )
     entity = next(iter(link))
-    assert entity.start_delete() == replace(entity, state=states.Received, current_process=Processes.DELETE)
+    assert entity.apply(Operations.START_DELETE) == replace(
+        entity, state=states.Received, current_process=Processes.DELETE
+    )
 
 
 def test_starting_delete_on_tainted_entity_returns_correct_commands() -> None:
@@ -108,4 +113,6 @@ def test_starting_delete_on_tainted_entity_returns_correct_commands() -> None:
         tainted_identifiers={create_identifier("1")},
     )
     entity = next(iter(link))
-    assert entity.start_delete() == replace(entity, state=states.Received, current_process=Processes.DELETE)
+    assert entity.apply(Operations.START_DELETE) == replace(
+        entity, state=states.Received, current_process=Processes.DELETE
+    )


### PR DESCRIPTION
This PR adds the unit of work which governs if and when operations applied to a link are persisted.

Before:
```python
link = gateway.create_link()
result = link.apply(Operations.START_PULL, requested=requested)
gateway.apply(result.updates)
result = link.apply(Operations.PROCESS, requested=requested)
gateway.apply(result.updates)
```

After:
```python
with uow:
    uow.link.apply(Operations.START_PULL, requested=requested)
    uow.link.apply(Operations.PROCESS, requested=requested)
    uow.commit()
```
